### PR TITLE
Allow jsonp requests

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -11,14 +11,9 @@ class AnnotationsController < ApplicationController
   
   def show
     return not_found unless current_annotation
-    respond_to do |format|
-      format.js do
-        json = current_annotation.canonical(:include_image_url => true, :include_document_url => true).to_json
-        js = "dc.embed.noteCallback(#{json})"
-        cache_page js if current_annotation.cacheable? && current_document.access == PUBLIC
-        render :js => js
-      end
-    end
+    @response = current_annotation.canonical(:include_image_url => true, :include_document_url => true)
+    cache_page js if current_annotation.cacheable? && current_document.access == PUBLIC
+    json_response  
   end
   
   # Print out all the annotations for a document (or documents.)


### PR DESCRIPTION
Return as json or jsonp if callback param given. 

I haven't tested this code as I don't have a running instance of documentCloud, but followed pattern from documents#show
