### PR TITLE
Add CORS preflight headers

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -18,6 +18,15 @@ class ApiController < ApplicationController
     redirect_to '/help/api'
   end
 
+  def cors_options
+    return bad_request unless params[:allowed_methods]
+    headers['Access-Control-Allow-Origin'] = '*'
+    headers['Access-Control-Allow-Methods'] = 'OPTIONS, ' + params[:allowed_methods].map(&:to_s).map(&:upcase).join(', ')
+    headers['Access-Control-Allow-Headers'] = 'Authorization'
+    headers['Access-Control-Allow-Credentials'] = 'true'
+    render :nothing => true
+  end
+
   def search
     opts = API_OPTIONS.merge(pick(params, :sections, :annotations, :entities, :mentions, :data))
     if opts[:mentions] &&= opts[:mentions].to_i

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,14 @@ ActionController::Routing::Routes.draw do |map|
     api.create_project  '/api/projects.:format',      :action => 'create_project', :conditions => {:method => :post}
     api.update_project  '/api/projects/:id.:format',  :action => 'update_project', :conditions => {:method => :put}
     api.delete_project  '/api/projects/:id.:format',  :action => 'destroy_project',:conditions => {:method => :delete}
+
+    api.with_options :conditions => {:method => :options}, :action => 'cors_options' do |cors_api|
+      cors_api.document '/api/documents/:id.:format', :allowed_methods => [ :put, :delete ]
+      cors_api.entities '/api/documents/:id/entities.:format', :allowed_methods => [ :get ]
+      cors_api.note     '/api/documents/:id/note/:note_id.:format', :allowed_methods => [ :get ]
+      cors_api.projects '/api/projects.:format', :allowed_methods => [ :get, :post ]
+      cors_api.project  '/api/projects/:id.:format', :allowed_methods => [ :put, :delete ]
+    end
   end
 
   # Bulk downloads.


### PR DESCRIPTION
When I start a CORS XHR request with custom headers (such as "Authorization") to a DocumentCloud URI, my browser sends a "preflight" request, asking DocumentCloud whether the request is allowed.

So I need DocumentCloud to say it is, please :).
