### PR TITLE
Backup Solr index.

### DIFF
--- a/app/actions/backup_solr.rb
+++ b/app/actions/backup_solr.rb
@@ -1,0 +1,62 @@
+require File.dirname(__FILE__) + '/support/setup'
+
+# This action will take a snapshot of the Solr search index, Tar & Gzip it and store it on S3.
+
+class BackupSolr < CloudCrowd::Action
+
+  def process
+    begin
+      
+      status = perform_solr_request('backup')
+      unless REXML::XPath.first( status, '//str[@name="status" and text()="OK"]' ).text
+        raise "Backup failed. xml:\n#{ status.to_s}"
+      end
+
+      status = perform_solr_request('details')
+      unless REXML::XPath.first( status, '//lst[@name="backup"]/str[@name="status" and text()="success"]' ).text
+        # Not 100% sure of what to do here.  My system always returns success but perhaps sometimes it returns pending
+        # or some such.  Need to test with a large corpus and see if the backup command returns immediatly or waits for completion
+        # For now: just raise an exception - We can examine the XML and adjust accordingly
+        raise "Backup (maybe?) failed - xml is:\n#{status.to_s}"
+      end
+      started      = REXML::XPath.first( status, '//lst[@name="backup"]/str[@name="startTime"]' ).text
+      basename     = Time.parse( started ).strftime( 'snapshot.%Y%m%d%H%M%S' )
+      path         = REXML::XPath.first( status, '//lst[@name="details"]/str[@name="indexPath"]' ).text
+      snapshot_dir = "#{path}/../#{basename}"
+      dest_file    = "#{basename}.tar.gz"
+
+      raise "Backup Directory: #{snapshot_dir} doesn't exist!" unless File.directory?( snapshot_dir )
+      Dir.mktmpdir do |temp_dir|
+        output = `tar -c -z -C #{snapshot_dir}/../ -f #{dest_file} #{basename}/  2>&1`
+        if 0 == $?.exitstatus
+          DC::Store::AssetStore.new.save_solr_backup( basename, dest_file )
+          FileUtils.rm_rf snapshot_dir
+          Rails.logger.info "Created sucessful backup of solr databse, saved to: #{dest_file}"
+        else
+          raise "Tar failed to compress backup: #{output}"
+        end
+      end
+
+    rescue Exception => e
+      LifecycleMailer.deliver_exception_notification(e)
+      raise e
+    end
+    true
+  end
+
+  private
+
+  def perform_solr_request( command )
+    ( host, port ) = solr_config
+    resp = Net::HTTP.get_response( URI.parse("http://#{host}:#{port}/solr/replication?command=#{command}" ))
+    raise resp.body unless resp.kind_of? Net::HTTPSuccess
+    return REXML::Document.new( resp.body )
+  end
+
+  def solr_config
+    return @solr_config_data if @solr_config_data
+    config = YAML::load(ERB.new( File.read( RAILS_ROOT + '/' + File.dirname(__FILE__)+'/../../config/sunspot.yml' )).result)
+    @solr_config_data = config[ Rails.env ]['solr'].values_at( 'hostname', 'port' )
+  end
+
+end

--- a/lib/dc/store/background_jobs.rb
+++ b/lib/dc/store/background_jobs.rb
@@ -16,6 +16,9 @@ module DC
         fire_job(:action => 'backup_database', :inputs => [true])
       end
 
+      def self.backup_solr
+        fire_job(:action => 'backup_solr', :inputs => [true])
+      end
 
       private
 

--- a/lib/dc/store/file_system_store.rb
+++ b/lib/dc/store/file_system_store.rb
@@ -97,6 +97,11 @@ module DC
         FileUtils.cp(path, local("backups/#{name}/#{Date.today}.dump"))
       end
 
+      def save_solr_backup(name, path)
+        ensure_directory("solr_backups/#{name}")
+        FileUtils.cp(path, local("solr_backups/#{name}/#{Date.today}.dump"))
+      end
+
       def set_access(document, access)
         # No-op for the FileSystemStore.
       end

--- a/lib/dc/store/s3_store.rb
+++ b/lib/dc/store/s3_store.rb
@@ -102,6 +102,10 @@ module DC
         bucket.put("backups/#{name}/#{Date.today}.dump", File.open(path))
       end
 
+      def save_solr_backup(name, path)
+        bucket.put("solr_backups/#{name}/#{Date.today}.dump", File.open(path))
+      end
+
       # This is going to be *extremely* expensive. We can thread it, but
       # there must be a better way somehow. (running in the background for now)
       def set_access(document, access)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -19,7 +19,12 @@ namespace :db do
   task :start do
     sh "sudo /etc/init.d/postgresql-8.4 start"
   end
-  
+
+  desc "Backup the Solr Index"
+  task :backup_solr => :environment do
+    DC::Store::BackgroundJobs.backup_solr
+  end
+
   desc "Apply db tasks in custom databases, for example  rake db:alter[db:migrate,test-es] applies db:migrate on the database defined as test-es in databases.yml"
   task :alter, [:task,:database] => :environment do |t, args|
     require 'activerecord'

--- a/lib/tasks/sunspot.rake
+++ b/lib/tasks/sunspot.rake
@@ -51,5 +51,10 @@ namespace :sunspot do
       model.solr_reindex reindex_options
     end
   end
-  
+
+  desc "Take a snapshot of the production solr database and store it on S3"
+  task :backup do
+    DC::Store::BackgroundJobs.backup_solr
+  end
+
 end

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -464,18 +464,14 @@
   <!-- Please refer to http://wiki.apache.org/solr/SolrReplication for details on configuring replication -->
   <!-- remove the <lst name="master"> section if this is just a slave -->
   <!-- remove  the <lst name="slave"> section if this is just a master -->
-  <!--
-<requestHandler name="/replication" class="solr.ReplicationHandler" >
-    <lst name="master">
-      <str name="replicateAfter">commit</str>
-      <str name="replicateAfter">startup</str>
-      <str name="confFiles">schema.xml,stopwords.txt</str>
-    </lst>
-    <lst name="slave">
-      <str name="masterUrl">http://localhost:8983/solr/replication</str>
-      <str name="pollInterval">00:00:60</str>
-    </lst>
-</requestHandler>-->
+  <requestHandler name="/replication" class="solr.ReplicationHandler" >
+      <lst name="master">
+          <str name="replicateAfter">commit</str>
+          <str name="replicateAfter">startup</str>
+          <str name="confFiles">schema.xml,stopwords.txt</str>
+      </lst>
+      <str name="maxNumberOfBackups">1</str>
+  </requestHandler>
   <!-- DisMaxRequestHandler allows easy searching across multiple fields
        for simple user-entered phrases.  It's implementation is now
        just the standard SearchHandler with a default query type


### PR DESCRIPTION
Create a new CloudCrowd action to snapshot the Solr index, tar/gzip it, and store it on S3.

This isn't quite ready to go into production, as I've been unable to find out if the solr backup command:
- Returns immediately, and you then need to repeatedly request status to determine if it's done
- Or whether it waits until the snapshot is completed to return the response.

On my system with a very small index, it returns immediately and then status says its completed.  We'll have to run some tests on a larger search index to determine which method we need to accommodate.

I'm not sure how production is setup to read the solr config.  I modified the file: /solr/conf/solrconfig.xml which is where the development sunspot is reading from. Production & Staging may be setup differently and their config's will have to be modified in order to turn enable ReplicationHandler.
