### PR TITLE
Save remote document to store after downloading

### DIFF
--- a/app/actions/document_import.rb
+++ b/app/actions/document_import.rb
@@ -20,6 +20,7 @@ class DocumentImport < CloudCrowd::Action
           end
         end
       end
+      DC::Store::AssetStore.new.save_original(document, file )
     else
       file = File.basename document.original_file_path
       File.open(file, 'w'){ |f| f << DC::Store::AssetStore.new.read_original(document) }


### PR DESCRIPTION
Fix an error when creating a document via the API with the URL parameter for the file.

When a document's source is specified as an URL it was downloaded but
then never saved to the (file|s3) store.  The import action then would
error out later when it attempted to read the meta data from the
original file.
