### PR TITLE
Add p3p header to DocumentsController#show

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,13 @@ class ApplicationController < ActionController::Base
     render :json => obj, :status => status
   end
 
+  # for use by actions that may be embedded in an iframe
+  # without this header IE will not send cookies
+  def set_p3p_header
+    # explanation of what these mean: http://www.p3pwriter.com/LRN_111.asp
+    headers['P3P'] = 'CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"'
+  end
+
   # If the request is asking for JSONP (eg. has a 'callback' parameter), then
   # short-circuit, and return the rendered JSONP.
   def jsonp_request?

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -208,11 +208,6 @@ class AuthenticationController < ApplicationController
     return data
   end
 
-  def set_p3p_header
-    # explanation of what these mean: http://www.p3pwriter.com/LRN_111.asp
-    headers['P3P'] = 'CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"'
-  end
-
   def clear_login_state
     reset_session
     cookies.delete 'dc_logged_in'

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,6 +5,7 @@ class DocumentsController < ApplicationController
   before_filter :login_required,      :only => [:update, :destroy]
   before_filter :prefer_secure,       :only => [:show]
   before_filter :api_login_optional,  :only => [:send_full_text, :send_pdf, :send_page_text, :send_page_image]
+  before_filter :set_p3p_header,      :only => [:show]
 
   SIZE_EXTRACTOR        = /-(\w+)\Z/
   PAGE_NUMBER_EXTRACTOR = /-p(\d+)/


### PR DESCRIPTION
Move the set_p3p_header method from authentications controller to a
protected method on the application controller so it can be shared
between all controllers who may be embedded in an iframe.

This should provide a solution for issue #39
