### PR TITLE
Consistent naming for document embed options

### DIFF
--- a/public/javascripts/ui/documents/document_embed_dialog.js
+++ b/public/javascripts/ui/documents/document_embed_dialog.js
@@ -62,7 +62,7 @@ dc.ui.DocumentEmbedDialog = dc.ui.Dialog.extend({
     this._showTextEl    = this.$('input[name=show_text]');
     this._showPDFEl     = this.$('input[name=show_pdf]');
     this._openToEl      = this.$('.open_to');
-    if (dc.app.preferences.get('embed_options')) this._loadPreferences();
+    if (dc.app.preferences.get('document_embed_options')) this._loadPreferences();
     this.setMode('document_embed', 'dialog');
     this.update();
     this.setStep();


### PR DESCRIPTION
When the document embed dialog is displayed, it checks to see if a preference for "embed_options" is present.  If it is it would attempt to read the preference for "document_embed_options".   Since preferences are also saved as "document_embed_options", the initial check should also be for "document_embed_options"
