### PR TITLE
refactored document.rb a bit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem 'nokogiri', '~> 1.6.0'
 gem 'right_aws', '2.0.1', :github=>'documentcloud/right_aws'        # Our patched version.
 
 
+gem 'stringex', require: 'stringex_lite'
+
 group :development, :test do
   gem 'guard-bundler'
   gem 'growl'
@@ -40,4 +42,7 @@ group :development, :test do
   gem 'minitest-spec-rails'
   gem 'guard-minitest'
   gem 'spring'
+
+  gem 'pry'
+  gem 'pry-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,8 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry-rails (0.3.2)
+      pry (>= 0.9.10)
     rack (1.5.2)
     rack-protection (1.5.1)
       rack
@@ -205,6 +207,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (~> 2.8)
     sqlite3 (1.3.8)
+    stringex (2.1.2)
     sunspot (2.1.0)
       pr_geohash (~> 1.0)
       rsolr (~> 1.0.7)
@@ -256,6 +259,8 @@ DEPENDENCIES
   pdftailor
   pg (~> 0.17)
   progress_bar
+  pry
+  pry-rails
   rails (~> 4.0)
   rake
   rdiscount (~> 2.1.6)
@@ -266,6 +271,7 @@ DEPENDENCIES
   sanitize (~> 2.0.6)
   spring
   sqlite3
+  stringex
   sunspot_matchers
   sunspot_rails (~> 2.1.0)
   sunspot_solr (~> 2.1.0)

--- a/app/models/concerns/document_concerns/annotatable.rb
+++ b/app/models/concerns/document_concerns/annotatable.rb
@@ -1,0 +1,32 @@
+module DocumentConcerns
+  module Annotatable
+    extend ActiveSupport::Concern
+
+
+    def annotations_with_authors(account, annotations=nil)
+      annotations ||= ordered_annotations(account)
+      Annotation.populate_author_info(annotations, account)
+      annotations
+    end
+
+    def ordered_annotations(account)
+      self.annotations.accessible(account).order('page_number asc, location asc nulls first')
+    end
+
+    # Determine the number of annotations on each page of this document.
+    def per_page_annotation_counts
+      self.annotations.group('page_number').count
+    end
+
+    # Reset the cached counter of public notes on the document.
+    def reset_public_note_count
+      count = annotations.unrestricted.count
+      if count != self.public_note_count
+        update_attributes :public_note_count => count
+      end
+    end
+
+
+
+  end
+end

--- a/app/models/concerns/document_concerns/canonical.rb
+++ b/app/models/concerns/document_concerns/canonical.rb
@@ -1,0 +1,298 @@
+module DocumentConcerns
+  module Canonical
+
+    extend ActiveSupport::Concern
+
+    DEFAULT_CANONICAL_OPTIONS = {
+      :sections => true, :annotations => true, :contributor => true
+    }
+
+    DISPLAY_DATE_FORMAT     = "%b %d, %Y"
+
+
+   # TODO: Make the to_json an extended form of the canonical.
+    def as_json(opts={})
+      json = {
+        :id                  => id,
+        :organization_id     => organization_id,
+        :account_id          => account_id,
+        :created_at          => created_at.to_date.strftime(DISPLAY_DATE_FORMAT),
+        :access              => access,
+        :page_count          => page_count,
+        :annotation_count    => annotation_count || 0,
+        :public_note_count   => public_note_count,
+        :title               => title,
+        :slug                => slug,
+        :source              => source,
+        :description         => description,
+        :organization_name   => organization_name,
+        :organization_slug   => organization_slug,
+        :account_name        => account_name,
+        :account_slug        => account_slug,
+        :related_article     => related_article,
+        :pdf_url             => pdf_url,
+        :thumbnail_url       => thumbnail_url( { :cache_busting => opts[:cache_busting] } ),
+        :full_text_url       => full_text_url,
+        :page_image_url      => page_image_url_template( { :cache_busting => opts[:cache_busting] } ),
+        :document_viewer_url => document_viewer_url,
+        :document_viewer_js  => canonical_url(:js),
+        :reviewer_count      => reviewer_count,
+        :remote_url          => remote_url,
+        :detected_remote_url => detected_remote_url,
+        :publish_at          => publish_at.as_json,
+        :hits                => hits,
+        :mentions            => mentions,
+        :total_mentions      => total_mentions,
+        :project_ids         => project_ids,
+        :char_count          => char_count,
+        :data                => data,
+        :language            => language
+      }
+      if opts[:annotations]
+        json[:annotations_url] = annotations_url if commentable?(opts[:account])
+        json[:annotations] = self.annotations_with_authors(opts[:account])
+      end
+      json
+    end
+
+
+    def canonical(options={})
+      options = DEFAULT_CANONICAL_OPTIONS.merge(options)
+      doc = ActiveSupport::OrderedHash.new
+      doc['id']                 = canonical_id
+      doc['title']              = title
+      doc['access']             = ACCESS_NAMES[access] if options[:access]
+      doc['pages']              = page_count
+      doc['description']        = description
+      doc['source']             = source
+      doc['created_at']         = created_at.to_formatted_s(:rfc822)
+      doc['updated_at']         = updated_at.to_formatted_s(:rfc822)
+      doc['canonical_url']      = canonical_url(:html, options[:allow_ssl])
+      doc['language']           = language
+      if commentable?(options[:account])
+        doc['annotations_url']  = annotations_url
+      end
+      if options[:contributor]
+        doc['contributor']      = account_name
+        doc['contributor_organization'] = organization_name
+      end
+      doc['display_language']   = display_language
+      doc['resources']          = res = ActiveSupport::OrderedHash.new
+      res['pdf']                = pdf_url
+      res['text']               = full_text_url
+      res['thumbnail']          = thumbnail_url
+      res['search']             = search_url
+      res['print_annotations']  = print_annotations_url
+      res['translations_url']   = translations_url
+      res['page']               = {}
+      res['page']['image']      = page_image_url_template({ :local => options[:local], :cache_busting => options[:cache_busting] })
+      res['page']['text']       = page_text_url_template(:local => options[:local])
+      res['related_article']    = related_article if related_article
+      res['annotations_url']    = annotations_url if commentable?(options[:account])
+      if options[:allow_detected]
+        res['published_url']    = published_url if published_url
+      else
+        res['published_url']    = remote_url if remote_url
+      end
+      doc['sections']           = ordered_sections.map {|s| s.canonical } if options[:sections]
+      doc['data']               = data if options[:data]
+      doc['language']           = language
+      if options[:annotations] && (options[:allowed_to_edit] || options[:allowed_to_review])
+        doc['annotations']      = self.annotations_with_authors(options[:account]).map {|a| a.canonical}
+      elsif options[:annotations]
+        doc['annotations']      = ordered_annotations(options[:account]).map {|a| a.canonical}
+      end
+      if self.mentions
+        doc['mentions']         = self.mentions
+      end
+      doc
+    end
+
+
+    ############## path and url stuff
+
+
+    def pathname
+      Pathname.new File.join('documents', id.to_s)    
+    end
+
+    # Ex: docs/1011
+    def path
+      pathname.to_path
+    end
+
+    def slug_path(ext=".#{original_extension}")
+      pathname.join(slug + ext).to_path
+    end
+
+    def original_file_path
+      slug_path
+    end
+
+    # Ex: docs/1011/sec-madoff-investigation.txt
+    def full_text_path
+      slug_path('.txt')
+    end
+
+    # Ex: docs/1011/sec-madoff-investigation.pdf
+    def pdf_path
+      slug_path('.pdf')
+    end
+
+    # Ex: docs/1011/sec-madoff-investigation.rdf
+    def rdf_path
+      slug_path('.rdf')
+    end
+
+    # Ex: docs/1011/pages
+    def pages_path
+      pathname.join('pages').to_path
+    end
+
+    def annotations_path
+      pathname.join('annotations').to_path
+    end
+
+    def canonical_id
+      "#{id}-#{slug}"
+    end
+
+    def canonical_path(format = :json)
+      "documents/#{canonical_id}.#{format}"
+    end
+
+    def canonical_cache_path
+      "/#{canonical_path(:js)}"
+    end
+
+    def project_ids
+      self.project_memberships.map {|m| m.project_id }
+    end
+
+    # Externally used image path, not to be confused with `page_image_path()`
+    def page_image_template
+      "#{slug}-p{page}-{size}.gif"
+    end
+
+    def page_text_template
+      "#{slug}-p{page}.txt"
+    end
+
+    def public_pdf_url
+      File.join(DC::Store::AssetStore.web_root, pdf_path)
+    end
+
+    def private_pdf_url
+      File.join(DC.server_root, pdf_path)
+    end
+
+    def pdf_url(direct=false)
+      return public_pdf_url  if public? || Rails.env.development?
+      return private_pdf_url unless direct
+      DC::Store::AssetStore.new.authorized_url(pdf_path)
+    end
+
+    def thumbnail_url( options={} )
+      page_image_url( 1, 'thumbnail', options )
+    end
+
+    def page_image_url(page, size, options={} )
+      path = page_image_path(page, size)
+      if public?
+        url = File.join( DC::Store::AssetStore.web_root, path )
+        url << "?#{updated_at.to_i}" if options[:cache_busting]
+        url
+      else
+        DC::Store::AssetStore.new.authorized_url path
+      end
+    end
+
+    def public_full_text_url
+      File.join(DC::Store::AssetStore.web_root, full_text_path)
+    end
+
+    def private_full_text_url
+      File.join(DC.server_root, full_text_path)
+    end
+
+    def full_text_url(direct=false)
+      return public_full_text_url if public? || Rails.env.development?
+      return private_full_text_url unless direct
+      DC::Store::AssetStore.new.authorized_url(full_text_path)
+    end
+
+    def document_viewer_url(opts={})
+      suffix = ''
+      suffix = "#document/p#{opts[:page]}" if opts[:page]
+      if ent = opts[:entity]
+        page  = self.pages.first(:conditions => {:page_number => opts[:page]})
+        occur = ent.split_occurrences.detect {|o| o.offset == opts[:offset].to_i }
+        suffix = "#entity/p#{page.page_number}/#{URI.escape(ent.value)}/#{occur.page_offset}:#{occur.length}"
+      end
+      if date = opts[:date]
+        occur = date.split_occurrences.first
+        suffix = "#entity/p#{occur.page.page_number}/#{URI.escape(date.date.to_s)}/#{occur.page_offset}:#{occur.length}" if occur.page
+      end
+      canonical_url(:html, opts[:allow_ssl]) + suffix
+    end
+
+    def canonical_url(format = :json, allow_ssl = false)
+      File.join(DC.server_root(:ssl => allow_ssl, :agnostic => format == :js), canonical_path(format))
+    end
+
+    def search_url
+      "#{DC.server_root}/documents/#{id}/search.json?q={query}"
+    end
+
+    def translations_url
+      "#{DC.server_root}/translations/{realm}/{language}"
+    end
+
+    def annotations_url
+      File.join(DC.server_root(:force_ssl => true, :agnostic => false ), annotations_path )
+    end
+
+    def print_annotations_url
+      "#{DC.server_root}/notes/print?docs[]=#{id}"
+    end
+
+    # Internally used image path, not to be confused with page_image_template()
+    def page_image_path(page_number, size)
+      File.join(pages_path, "#{slug}-p#{page_number}-#{size}.gif")
+    end
+
+    def page_text_path(page_number)
+      File.join(pages_path, "#{slug}-p#{page_number}.txt")
+    end
+
+    def public_page_image_template
+      File.join(DC::Store::AssetStore.web_root, File.join(pages_path, page_image_template))
+    end
+
+    def private_page_image_template
+      File.join(DC.server_root, File.join(pages_path, page_image_template))
+    end
+
+    def page_image_url_template(opts={})
+      tmpl = if opts[:local]
+               File.join(slug, page_image_template )
+             elsif self.public? || Rails.env.development?
+               public_page_image_template
+             else
+               private_page_image_template
+             end
+      tmpl << "?#{updated_at.to_i}" if opts[:cache_busting]
+      tmpl
+    end
+
+    def page_text_url_template(opts={})
+      return File.join(slug, page_text_template) if opts[:local]
+      File.join(DC.server_root, File.join(pages_path, page_text_template))
+    end
+
+
+
+
+
+  end
+end

--- a/app/models/concerns/document_concerns/searchable.rb
+++ b/app/models/concerns/document_concerns/searchable.rb
@@ -1,0 +1,70 @@
+module DocumentConcerns
+  module Searchable
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Main document search method -- handles queries.
+      def search(query, options={})
+        query = DC::Search::Parser.new.parse(query) if query.is_a? String
+        query.run(options)
+      end
+    end
+
+    def reindex_all!(access=nil)
+      Page.refresh_page_map(self)
+      EntityDate.reset(self)
+      pages = self.reload.pages
+      Sunspot.index pages
+      Sunspot.commit
+      reprocess_entities if calais_id
+      upload_text_assets(pages, access)
+      self.access = access if access
+      self.save!
+    end
+
+
+    included do
+      # The definition of the Solr search index. Via sunspot-rails.
+      searchable do
+
+        # Full Text...
+        text :title, :default_boost => 2.0
+        text :source
+        text :description
+        text :full_text do
+          self.combined_page_text
+        end
+
+        # Attributes...
+        string  :title
+        string  :source
+        string  :language
+        time    :created_at
+        boolean :published, :using => :published?
+        integer :id
+        integer :account_id
+        integer :organization_id
+        integer :access
+        integer :page_count
+        integer :hit_count
+        integer :public_note_count
+        integer :project_ids, :multiple => true do
+          self.project_memberships.map {|m| m.project_id }
+        end
+
+        # Entities...
+        # DC::ENTITY_KINDS.each do |entity|
+        #   text(entity) { self.entity_values(entity) }
+        #   string(entity, :multiple => true) { self.entity_values(entity) }
+        # end
+
+        # Data...
+        dynamic_string :data do
+          self.docdata ? self.docdata.data.symbolize_keys : {}
+        end
+      end
+    end
+
+
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module DC
     # config.i18n.default_locale = :de
 
     # DocumentCloud-specific configuration.
-    ::DC::SECRETS.merge!   YAML.load_file("#{Rails.root}/secrets/secrets.yml")[Rails.env]
+    ::DC::SECRETS.merge!   YAML.load_file(Rails.root.join('config','server', 'secrets/secrets.yml'))[Rails.env]
     ::DC::CONFIG.merge! YAML.load( ERB.new(File.read( Rails.root.join('config','document_cloud.yml') ) ).result )[Rails.env]
 
     ::DC::ANALYTICS_DB = YAML.load(ERB.new(File.read("#{Rails.root}/config/database_analytics.yml")).result(binding))[Rails.env]

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,4 +1,4 @@
-<% secrets = YAML.load_file(File.join(Rails.root, 'secrets/secrets.yml'))[ENV['RAILS_ENV'] || 'development'] %>
+<% secrets = DC::SECRETS %>
 
 defaults: &defaults
   adapter: postgresql

--- a/config/database_analytics.yml
+++ b/config/database_analytics.yml
@@ -1,4 +1,4 @@
-<% secrets = YAML.load_file('secrets/secrets.yml')[ENV['RAILS_ENV'] || 'development'] %>
+<% secrets = DC::SECRETS %>
 
 defaults: &defaults
   adapter: postgresql

--- a/config/document_cloud.yml
+++ b/config/document_cloud.yml
@@ -1,4 +1,4 @@
-<% secrets = YAML.load_file('./secrets/secrets.yml')[ENV['RAILS_ENV'] || "development"] %>
+<% secrets = DC::SECRETS %>
 defaults: &defaults
   cloud_crowd_server:   http://dev.dcloud.org:8080
   server_root:          dev.dcloud.org

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -206,5 +206,24 @@ class DocumentTest < ActiveSupport::TestCase
     assert_job_action 'reprocess_entities'
   end
 
+  # TODO: I don't understand assert tests so this is just a start - Dan
+  # ensure_slugged calls the class method .format_title_slug
+  #  which uses StringEx#to_url https://github.com/rsl/stringex
+  def test_title_slug_is_cleaned_up_and_around_50_chars
+    assert_equal Document.format_title_slug("Héllo World!"), "hello-world"
+
+    # asserts that it is as close to 50 chars as possible, truncate to nearest whole word
+    # also notes StringEx's fanciness, converting & to 'and', which may not be desirable...
+    assert_equal( 
+        Document.format_title_slug("rock it both in Español style & kick it en Français plu ENGLISH!"), 
+        'rock-it-both-in-espanol-style-and-kick-it-en'
+    )
+  end
+
+  # note: StringEx fanciness will mess up legacy titles. Not sure what implications that has...
+  def test_format_title_slug_doesnt_screw_up_legacy_titles
+    # TODO
+  end
 
 end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,9 @@ require 'rails/test_help'
 require 'sunspot_matchers/test_helper'
 require 'turn/autorun'
 
+ require "minitest/autorun"
+ require 'pry'
+
 PROCESSING_JOBS = []
 
 Turn.config do |c|


### PR DESCRIPTION
Some house cleaning to make it easier to test individual components as DC migrates to Rails 4. I made some DocumentConcerns and arbitrarily moved sections of document.rb into them. The only thing I can say is that the tests still pass and I even fixed a failing test. 

I also added some gems, which may not be cool. Pry, because how can you not have it. And 'string_ex', which I saw was being used by RapGenius in their template app, so maybe that's not a good thing. But it does seem to have robust Unicode conversion that may be easier to test/maintain than what was in `ensure_slugged`...Since `ensure_slugged` was only an after_create call, I'm assuming this won't impact legacy slugs.

https://github.com/rsl/stringex

I also don't know how to use postgres so I kept getting an error about `remote_urls - PG::UndefinedTable: ERROR:  relation "remote_urls" does not exist`...even though I tried to manually generate it from the included SQL and schema. Otherwise, tests pass for now.
