### PR TITLE
Adding `raw` to output of @help_content

### DIFF
--- a/app/views/home/help.html.erb
+++ b/app/views/home/help.html.erb
@@ -7,7 +7,7 @@
 <div id="content">
   <div id="help">
 
-    <%= @help_content %>
+    <%= raw @help_content %>
 
   </div>
 </div>


### PR DESCRIPTION
Given that `@help_content` is raw HTML from the controller: https://github.com/documentcloud/documentcloud/blob/276bd3e3d8ffbeb689508066dad55697c0e43776/app/controllers/workspace_controller.rb

I think you have to use `raw` to override Rails 4.0 default sanitizing 

Example problem pages:
- http://www.documentcloud.org/help/api
- http://www.documentcloud.org/featured
