### PR TITLE
Upgrade migrations to work with Rails 4.

### DIFF
--- a/db/migrate/20100114170350_regenerate_thumbnails.rb
+++ b/db/migrate/20100114170350_regenerate_thumbnails.rb
@@ -4,8 +4,8 @@ class RegenerateThumbnails < ActiveRecord::Migration
   def self.up
     # wait for a second for CloudCrowd to come online.
     sleep 2
-    ids = Document.all(:select => 'id').map {|d| d.id }
-    RestClient.post(DC_CONFIG['cloud_crowd_server'] + '/jobs', {:job => {
+    ids = Document.pluck(:id).to_a
+    RestClient.post(DC::CONFIG['cloud_crowd_server'] + '/jobs', {:job => {
       'action'  => 'regenerate_thumbnails',
       'inputs'  => ids
     }.to_json})

--- a/db/migrate/20100413132825_switch_over_to_solr_altogether.rb
+++ b/db/migrate/20100413132825_switch_over_to_solr_altogether.rb
@@ -2,13 +2,16 @@ class SwitchOverToSolrAltogether < ActiveRecord::Migration
   extend DC::Store::MigrationHelpers
 
   def self.up
+    found_pages = false
+
     # Index with Solr.
-    Page.find_in_batches(:conditions => ['true']) do |pages|
+    Page.find_in_batches do |pages|
+      found_pages ||= true
       Sunspot.index(pages)
     end
 
     # Commit the updates.
-    Sunspot.commit
+    Sunspot.commit if found_pages
 
     # Remove the Postgres indexes.
     remove_full_text_index :annotations, :content

--- a/db/migrate/20110303200824_project_is_reviewer.rb
+++ b/db/migrate/20110303200824_project_is_reviewer.rb
@@ -1,9 +1,9 @@
 class ProjectIsReviewer < ActiveRecord::Migration
   def self.up
-    projects = Project.find(:all, :conditions => ["reviewer_document_id IS NOT NULL"])
+    ids = Project.where("reviewer_document_id IS NOT NULL").pluck(:id).to_a
     add_column :projects, :hidden, :boolean, :default => false, :null => false
     remove_column :projects, :reviewer_document_id
-    projects.each {|p| p.update_attributes :hidden => true }
+    Project.where(id: ids).update_all(hidden: true)
   end
 
   def self.down

--- a/db/migrate/20110505172648_strip_query_string_remote_urls.rb
+++ b/db/migrate/20110505172648_strip_query_string_remote_urls.rb
@@ -2,7 +2,7 @@ class StripQueryStringRemoteUrls < ActiveRecord::Migration
   
   def self.up
     doc_ids = []
-    docs = RemoteUrl.all(:conditions => ['url LIKE ? AND document_id is not NULL', '%?%']).group_by {|u| u.document_id }
+    docs = RemoteUrl.where(['url LIKE ? AND document_id IS NOT NULL', '%?%']).to_a.group_by(&:document_id)
     docs.each do |id, doc_urls|
       docs[id] = doc_urls.group_by {|h| h.date_recorded }
     end

--- a/db/migrate/20130108201748_remove_role_and_organization_from_accounts.rb
+++ b/db/migrate/20130108201748_remove_role_and_organization_from_accounts.rb
@@ -1,6 +1,6 @@
 class RemoveRoleAndOrganizationFromAccounts < ActiveRecord::Migration
   def self.up
-    remove_index :accounts, 'organization_id'
+    remove_index :accounts, name: 'fk_organization_id'
     
     remove_column :accounts, 'role'
     remove_column :accounts, 'organization_id'
@@ -15,5 +15,7 @@ class RemoveRoleAndOrganizationFromAccounts < ActiveRecord::Migration
     end
     change_column 'accounts', 'role',            :integer, :null => false
     change_column 'accounts', 'organization_id', :integer, :null => false
+
+    add_index "accounts", ["organization_id"], :name => "fk_organization_id"
   end
 end


### PR DESCRIPTION
I ran `rake db:create db:migrate` when trying to get unit tests working, and I ran into a few errors.

Here are the fixes.