### PR TITLE
Fail optional API auth on bad email/password.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,16 +97,24 @@ class ApplicationController < ActionController::Base
 
   def api_login_required
     authenticate_or_request_with_http_basic("DocumentCloud") do |email, password|
-      return false unless @current_account = Account.log_in(email, password)
-      @current_organization = @current_account.organization
-      true
+      @current_account = Account.log_in(email, password)
+      if @current_account.blank?
+        false
+      else
+        @current_organization = @current_account.organization
+        true
+      end
     end
   end
 
   def api_login_optional
-    return if request.authorization.blank?
-    return unless @current_account = Account.log_in(*BasicAuth.user_name_and_password(request))
-    @current_organization = @current_account.organization
+    if request.authorization.blank?
+      # Public user
+      true
+    else
+      # The user is trying to log in. If the username/password is wrong, fail.
+      api_login_required
+    end
   end
   
   def allow_iframe

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -63,6 +63,23 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal doc.canonical_id, json_body['documents'].first['id']
   end
 
+  def test_search_works_if_authenticated
+    # authentication is optional, but it can get you more docs
+    account = accounts(:louis)
+    request.headers['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(account.email, 'password')
+    get(:search, q: "document:#{doc.id}", format: :json)
+    assert_equal 1, json_body['total']
+    assert_equal doc.canonical_id, json_body['documents'].first['id']
+  end
+
+  def test_search_doesnt_work_if_authentication_fails
+    # otherwise the user might enter the wrong password and be sad the extra docs are missing
+    # https://github.com/documentcloud/documentcloud/issues/89
+    request.headers['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("WRONG-email@example.org", "WRONG-password")
+    get(:search, q: "document:#{doc.id}", format: :json)
+    assert_response 401
+  end
+
   def test_it_requires_authentication
     [ :upload, :project, :projects, :update, :destroy, :create_project, :update_project, :destroy_project ].each do | action |
       get action


### PR DESCRIPTION
Fixes #89.

Right now, entering the wrong username/password when making an API search request will _always_ give a `200` response, even if the username and password are wrong. That makes it difficult for clients to check whether they're entering the correct username/password.

This new logic seems simple enough: if the user is entering a username/password, then check them; otherwise, don't.

I had to alter `api_login_required` because my test failed until I did. (The `return false unless` line seemed to go ahead, even though `Account.log_in` failed.) I'm not sure if there are any real-world repercussions to my change, but if there are any, they're probably good ones :).