### PR TITLE
Disable SAMEORIGIN on login page.

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -3,7 +3,7 @@ class AuthenticationController < ApplicationController
   before_action :bouncer, :except => [:callback] if Rails.env.staging?
 
   skip_before_action :verify_authenticity_token, :only => [:login]
-  after_action :allow_iframe, :only=>[:iframe,:inner_iframe,:iframe_success,:iframe_logout]
+  after_action :allow_iframe, :only=>[:iframe,:inner_iframe,:iframe_success,:iframe_logout,:login]
 
   before_action :secure_only,     :only => [:login]
 


### PR DESCRIPTION
This lets https://www.overviewproject.org display private DocumentCloud
documents to its users even when they aren't logged in to DocumentCloud.
The steps look like this:
1. User opens /documents/X in an iframe (no X-Frame-Options)
2. DocumentCloud sees it's a private document; it redirects to /login
3. (after this patch), the browser loads /login in the iframe
4. The user enters email/password
5. Login succeeds; DocumentCloud redirects to /documents/X

This does open DocumentCloud up to clickjacking. Blame WebKit: it's the
only browser that doesn't allow an ALLOW-FROM X-Frame-Options setting,
which would limit the iframe to https://www.overviewproject.org.
https://bugs.webkit.org/show_bug.cgi?id=94836#c13

From Overview's point of view, there are no reliable workarounds.
