### PR TITLE
Updated documentcloud-notes github reference

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "dependencies":{
     "jquery": "1.11.1",
     "backbone": "1.1.2",
-    "documentcloud-notes": "git@github.com:documentcloud/documentcloud-notes.git"
+    "documentcloud-notes": "git://github.com/documentcloud/documentcloud-notes.git"
   },
   "moduleType": [
     "globals"


### PR DESCRIPTION
The previous method of referencing is prone to failures [1] with frequent access loss. This change is a simple and commonly used (jQuery et al) but could still fail on certain networks. If it does, `https://` works fine.

[1]: https://github.com/gitlabhq/gitlabhq/issues/3424