### PR TITLE
Use region specified in documentcloud.yml

### DIFF
--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -6,5 +6,6 @@ AWS.config(
   :logger            => Rails.logger,
   :http_idle_timeout => 60,
   :http_open_timeout => 30,
-  :http_read_timeout => 300
+  :http_read_timeout => 300,
+  :region            => DC::CONFIG['aws_zone']
 )


### PR DESCRIPTION
This defaults to `us-east-1`. Having the region specified in config allows for easy working.

See: http://ruby.awsblog.com/post/TxVOTODBPHAEP9/Working-with-Regions