### PR TITLE
Content-type: text/plain; charset=utf-8 when serving text from S3

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -474,7 +474,7 @@ class Document < ActiveRecord::Base
   def pdf_url(direct=false)
     return public_pdf_url  if public? || Rails.env.development?
     return private_pdf_url unless direct
-    DC::Store::AssetStore.new.authorized_url(pdf_path)
+    DC::Store::AssetStore.new.authorized_url(pdf_path, :content_type => 'application/pdf')
   end
 
   def thumbnail_url( options={} )
@@ -503,7 +503,7 @@ class Document < ActiveRecord::Base
   def full_text_url(direct=false)
     return public_full_text_url if public? || Rails.env.development?
     return private_full_text_url unless direct
-    DC::Store::AssetStore.new.authorized_url(full_text_path)
+    DC::Store::AssetStore.new.authorized_url(full_text_path, :content_type => 'text/plain; charset=utf-8')
   end
 
   def document_viewer_url(opts={})

--- a/lib/dc/store/aws_s3_store.rb
+++ b/lib/dc/store/aws_s3_store.rb
@@ -39,8 +39,19 @@ module DC
         bucket.objects[path].content_length
       end
       
-      def authorized_url(path)
-        bucket.objects[path].url_for(:read, :secure => Thread.current[:ssl], :expires => AUTH_PERIOD).to_s
+      # Returns a temporary S3 URL.
+      #
+      # Caller may specify content type to override whatever the server sends.
+      # (We don't just calculate the MIME type from the filename, because we
+      # may want "text/plain; charset=utf-8".)
+      def authorized_url(path, opts={})
+        request_options = {
+          :secure => Thread.current[:ssl],
+          :expires => AUTH_PERIOD
+        }
+        request_options[:response_content_type] = opts[:content_type] if opts[:content_type]
+
+        bucket.objects[path].url_for(:read, request_options).to_s
       end
       
       def list(path)

--- a/lib/dc/store/file_system_store.rb
+++ b/lib/dc/store/file_system_store.rb
@@ -25,7 +25,7 @@ module DC
         File.size?(local(path))
       end
 
-      def authorized_url(path)
+      def authorized_url(path, opts={})
         File.join(self.class.web_root, path)
       end
 


### PR DESCRIPTION
UNTESTED CODE. I can't even run DocumentCloud locally. Please help :).

When DocumentCloud serves up an authorized S3 text URL, S3 sets the content type. (DocumentCloud seems to set a content-type on its `302 Found` response, but that doesn't do anything.)

In several documents we tested (document `1355983`, for instance), S3 responds with `Content-Type: `. It should be `Content-Type: text/plain; charset=utf-8`.

The HTTP default is `ISO-8859-1`, which is wrong. Chrome and Firefox override the default when they detect the web server is wrong. At Overview, we'd rather not go down that route.

S3 lets you specify a `:response_content_type`. That adds the desired content type to the query string, so that S3 serves it correctly.

I haven't tested this code -- I don't have a working DocumentCloud setup, and this whole area of the code base isn't unit-tested. But it might Just Work; and even if it doesn't, the intent of this pull request is clear.