### PR TITLE
Use render :plain instead of render :text

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -191,7 +191,7 @@ class AdminController < ApplicationController
   # Ensure that the length of the pending document queue is ok.
   def queue_length
     ok = Document.pending.count <= Document::WARN_QUEUE_LENGTH
-    render :text => ok ? 'OK' : 'OVERLOADED'
+    render :plain => ok ? 'OK' : 'OVERLOADED'
   end
 
   # Spin up a new CloudCrowd medium worker, for processing. It takes a while

--- a/app/controllers/ajax_help_controller.rb
+++ b/app/controllers/ajax_help_controller.rb
@@ -55,7 +55,7 @@ class AjaxHelpController < ApplicationController
     contents = File.read( help_for_language( language, resource ) )
     links = File.exists?( links_for_language( language, resource ) ) ?
       File.read( links_for_language( language, resource ) ) : ""
-    render :text => RDiscount.new(contents+links).to_html, :type => :html
+    render :html => RDiscount.new(contents+links).to_html
   end
 
 end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -79,7 +79,7 @@ class AuthenticationController < ApplicationController
 
   # this is needed for running omniauth on rails 2.3.  Without it the route
   # causes an error even though omniauth is intercepting it
-  def blank; render :text => "Not Found.", :status => 404 end
+  def blank; render :plain => "Not Found.", :status => 404 end
 
   # this is the endpoint for an embedded document to obtain addition information
   # about the document as well as the current user

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -213,7 +213,7 @@ class DocumentsController < ApplicationController
     return not_found unless current_page
     @response = current_page.text
     return if jsonp_request?
-    render :text => @response
+    render :plain => @response
   end
 
   def set_page_text

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -30,14 +30,14 @@ class ImportController < ApplicationController
       record.document.update_attributes(:access => DC::Access::ERROR) if record && record.document
     end
     ProcessingJob.destroy_all(:cloud_crowd_id => job['id'])
-    #render :text => '201 Created', :status => 201
-    render :text => "Created but don't clean up the job right now."
+    #render :plain => '201 Created', :status => 201
+    render :plain => "Created but don't clean up the job right now."
   end
 
   # CloudCrowd is done changing the document's asset access levels.
   # 201 created cleans up the job.
   def update_access
-    render :text => '201 Created', :status => 201
+    render :plain => '201 Created', :status => 201
   end
 
 end


### PR DESCRIPTION
You missed a spot when upgrading to Rails 4.1: http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#rendering-content-from-string

DocumentCloud is serving some responses with the wrong content types. This doesn't negatively impact Overview; it probably doesn't negatively impact anybody else, either. But it's always nice to be correct.

Sorry, I haven't tested this stuff because my local DocumentCloud install isn't set up.