### PR TITLE
Fixes for home page links to examples.

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -35,13 +35,12 @@
   </div>
 
   <div class="graf">
-    When Memphis&rsquo; 
-    <a href="http://www.commercialappeal.com/">Commercial Appeal</a> published
-    <a href="http://www.commercialappeal.com/withers-exposed/">Ernest Withers: Exposed</a>,
-    an extensive investigation which revealed that the civil rights photographer
-    had been working as an FBI informant, they were able to point readers right to
-    <a href="http://www.commercialappeal.com/withers-exposed/pages-from-foia-reveal-withers-as-informant/#document/p2/a2431">the passage</a>
-    that revealed his true identity.
+    When <a href="http://news.stlpublicradio.org/">St. Louis Public Radio</a> published
+    <a href="http://apps.stlpublicradio.org/ferguson-project/evidence.html">thousands
+    of pages</a> of grand jury testimony, forensic reports and other documents related 
+    to the death of Michael Brown in Ferguson, Mo., they served their audience by
+    <a href="https://www.documentcloud.org/documents/1370501-grand-jury-volume-12.html#document/p32/a189751">
+    identifying passages</a> containing key eyewitness accounts.
   </div>
 
   <hr />
@@ -55,7 +54,7 @@
     join thousands of other primary source documents in our 
     public catalog.
     Use our document viewer to 
-    <a href="http://www.pbs.org/newshour/rundown/documents/mark-twain-concerning-the-interview.html">embed documents on your own website</a> 
+    <a href="http://www.pbs.org/newshour/spc/rundown/documents/mark-twain-concerning-the-interview.html">embed documents on your own website</a> 
     and introduce your audience to the larger paper trail behind your story.
   </div>
 


### PR DESCRIPTION
New example for annotations since the Commercial Appeal's Withers content is no longer at those links. Also, PBS link is updated to current location.