### PR TITLE
Replace static blog headlines with real live ones

### DIFF
--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -60,7 +60,7 @@
       News
     </div>
     <ul id="news_headlines">
-      <li>Fetching headlines…</li>
+      <li><img style="vertical-align:text-top" src="/images/search_embed/embed/spinner_circle.gif"/> Headlines <a href="http://en.wikipedia.org/wiki/To_come_%28publishing%29">TK</a></li>
     </ul>
   </div>
 

--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -59,28 +59,8 @@
     <div class="section_title">
       News
     </div>
-    <ul>
-      <li>
-        March 12, 2015 &mdash; <a href="http://blog.documentcloud.org/blog/2015/03/hungarian-norwegian-swedish-ocr-support-added/">Hungarian, Norwegian, Swedish OCR support added</a>
-      </li>
-      <li>
-        March 7, 2015 &mdash; <a href="http://blog.documentcloud.org/blog/2015/03/145812/">Shearing PDFs with PDFShaver at DocumentCloud</a>
-      </li>
-      <li>
-        March 7, 2015 &mdash; <a href="http://blog.documentcloud.org/blog/2015/03/job-posting-documentcloud-seeks-data-engineer/">Job posting: DocumentCloud seeks data engineer</a>
-      </li>
-      <li>
-        Feb. 26, 2015 &mdash; <a href="http://blog.documentcloud.org/blog/2015/02/documentcloud-at-nicar-2015-atlanta/">Catch DocumentCloud at NICAR 2015 in Atlanta</a>
-      </li>
-      <li>
-        Jan. 20, 2015 &mdash; <a href="http://blog.documentcloud.org/blog/2015/01/ahead-for-2015-a-faster-more-productive-documentcloud/">Ahead for 2015: A Faster, More Productive DocumentCloud</a>
-      </li>
-      <li>
-        Jan. 6, 2015 &mdash; <a href="http://blog.documentcloud.org/blog/2015/01/welcome-aboard-anthony-debarros/">Welcome aboard, Anthony DeBarros!</a>
-      </li>
-      <li>
-        Sept. 25, 2014 &mdash; <a href="http://blog.documentcloud.org/blog/2014/09/how-we-made-documentcloud-embeds-responsive/">How we made DocumentCloud note embeds responsive</a>
-      </li>
+    <ul id="news_headlines">
+      <li>Fetching headlines…</li>
     </ul>
   </div>
 

--- a/app/views/jst/workspace/home/blog_headline.jst
+++ b/app/views/jst/workspace/home/blog_headline.jst
@@ -1,0 +1,3 @@
+<li>
+    <%= date %> &mdash; <a href="<%= url %>"><%= title %></a>
+</li>

--- a/public/javascripts/home/home.js
+++ b/public/javascripts/home/home.js
@@ -2,6 +2,7 @@ $(function() {
 
   window.HomePage = Backbone.View.extend({
 
+    BLOG_HEADLINES_URL : 'http://blog.documentcloud.org/?json=get_recent_posts&count=7&callback=?',
     FAVORITES_URL : '//twitter.com/favorites/documentcloud.json?callback=?',
 
     el : document.body,
@@ -21,7 +22,7 @@ $(function() {
       this.emailInput     = $('#account_email');
       this.passwordInput  = $('#account_password');
       _.invoke([this.box, this.emailInput, this.passwordInput], 'placeholder');
-      $(_.bind(this.loadTweets, this));
+      $(_.bind(this.loadBlogHeadlines, this));
     },
 
     login : function() {
@@ -62,6 +63,24 @@ $(function() {
           }));
         });
         $('#tweets').html(html).show();
+      });
+    },
+
+    loadBlogHeadlines : function() {
+      var formatDate = DateUtils.create("%b %e, %Y");
+      $.getJSON(this.BLOG_HEADLINES_URL, function(json) {
+        var posts = json.posts;
+        if (posts.length > 0) {
+          var headlines_html = "";
+          _.each(posts, function(post, i) {
+            headlines_html += JST['home/blog_headline'](_.extend(post, {
+              date : formatDate(DateUtils.parseRfc(post.date)),
+            }));
+          });
+          $('#news_headlines').html(headlines_html);
+        } else {
+          $('#news').hide();
+        }
       });
     }
 

--- a/public/javascripts/home/home.js
+++ b/public/javascripts/home/home.js
@@ -2,7 +2,7 @@ $(function() {
 
   window.HomePage = Backbone.View.extend({
 
-    BLOG_HEADLINES_URL : 'http://blog.documentcloud.org/?json=get_recent_posts&count=7&callback=?',
+    BLOG_HEADLINES_URL : '//blog.documentcloud.org/?json=get_recent_posts&count=7&callback=?',
     FAVORITES_URL : '//twitter.com/favorites/documentcloud.json?callback=?',
 
     el : document.body,


### PR DESCRIPTION
Old way: manually update the info site templates.
New way: fetch a headline feed from the blog client-side.

Also, stop trying to fetch Twitter favorites, since it doesn't work and we don't display them anyway.