### PR TITLE
Oembed

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -176,6 +176,10 @@ class ApiController < ApplicationController
     json nil
   end
 
+  def oembed
+    json_response
+  end
+
   # Allow logging of all actions, apart from secure uploads.
   def logger
     params[:secure] ? nil : super

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -176,6 +176,10 @@ class ApiController < ApplicationController
       return render :status => 400, :text => "Missing valid URL parameter"
     end
 
+    if url.host != DC::CONFIG['server_root']
+      return render :status => 404, :text => "Resource not found"
+    end
+
     respond_to do |format|
       format.json do
         @response = {

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -184,7 +184,7 @@ class ApiController < ApplicationController
     resource_url = url_for(resource_params.merge(:format => 'js'))
     resource = resource_seralizer_klass.new(resource_params[:id], resource_url)
     
-    embed = DC::OEmbed.new(resource)
+    embed = DC::Embed::DocumentOEmbed.new(resource)
     
     respond_to do |format|
       format.json do

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -184,7 +184,8 @@ class ApiController < ApplicationController
     resource_url = url_for(resource_params.merge(:format => 'js'))
     resource = resource_seralizer_klass.new(resource_params[:id], resource_url)
     
-    embed = DC::Embed::DocumentOEmbed.new(resource)
+    #config = pick(DC::Embed::DocumentOEmbed.config_keys, params)
+    embed = DC::Embed::Document.new(resource, {}, {:strategy => :oembed})
     
     respond_to do |format|
       format.json do

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -171,6 +171,18 @@ class ApiController < ApplicationController
   end
 
   def oembed
+    @response = {
+      :type             => "rich",
+      :version          => "1.0",
+      :provider_name    => "DocumentCloud",
+      :provider_url     => DC.server_root,
+      :cache_age        => 300,
+      :resource_url     => nil,
+      :height           => nil,
+      :width            => nil,
+      :display_language => nil,
+      :html             => nil,
+    }
     json_response
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -173,14 +173,10 @@ class ApiController < ApplicationController
   def oembed
 
     url = URI.parse(CGI.unescape(params[:url])) rescue nil
-    if params[:url].blank? or !url
-      return  render :status => 400, :text => "Missing valid URL parameter"
-    end
+    return bad_request if params[:url].blank? or !url
 
     resource_params = Rails.application.routes.recognize_path(url.path) rescue nil
-    unless url.host == DC::CONFIG['server_root'] and resource_embeddable?(resource_params)
-      return render :status => 404, :text => "Resource not found"
-    end
+    return not_found unless url.host == DC::CONFIG['server_root'] and resource_embeddable?(resource_params)
 
     respond_to do |format|
       format.json do

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -195,9 +195,8 @@ class ApiController < ApplicationController
         json_response
       end
       format.all do
-        # As per the oEmbed spec, unrecognized formats should get a 501
-        # error.
-        render :status => 501, :text => "Unsupported request type"
+        # Per the oEmbed spec, unrecognized formats should trigger a 501
+        not_implemented
       end
     end
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -19,12 +19,6 @@ class ApiController < ApplicationController
     redirect_to '/help/api'
   end
 
-  def cors_options
-    return bad_request unless params[:allowed_methods]
-    maybe_set_cors_headers
-    render :nothing => true
-  end
-
   def search
     opts = API_OPTIONS.merge(pick(params, :sections, :annotations, :entities, :mentions, :data))
     if opts[:mentions] &&= opts[:mentions].to_i
@@ -178,6 +172,12 @@ class ApiController < ApplicationController
 
   def oembed
     json_response
+  end
+
+  def cors_options
+    return bad_request unless params[:allowed_methods]
+    maybe_set_cors_headers
+    render :nothing => true
   end
 
   # Allow logging of all actions, apart from secure uploads.

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -184,7 +184,7 @@ class ApiController < ApplicationController
     resource_url = url_for(resource_params.merge(:format => 'js'))
     resource = resource_seralizer_klass.new(resource_params[:id], resource_url, :document)
     
-    config = pick(params, DC::Embed.embed_klass(resource).config_keys)
+    config = pick(params, *DC::Embed.embed_klass(resource.type).config_keys)
     embed = DC::Embed.embed_for(resource, config, {:strategy => :oembed})
     
     respond_to do |format|

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -171,12 +171,14 @@ class ApiController < ApplicationController
   end
 
   def oembed
+
     url = URI.parse(CGI.unescape(params[:url])) rescue nil
-    if params[:url].blank? || !url
-      return render :status => 400, :text => "Missing valid URL parameter"
+    if params[:url].blank? or !url
+      return  render :status => 400, :text => "Missing valid URL parameter"
     end
 
-    unless url.host == DC::CONFIG['server_root'] # && Document.accessible(nil, nil).exists?(params[:id].to_i)
+    resource_params = Rails.application.routes.recognize_path(url.path) rescue nil
+    unless url.host == DC::CONFIG['server_root'] and resource_embeddable?(resource_params)
       return render :status => 404, :text => "Resource not found"
     end
 
@@ -216,6 +218,14 @@ class ApiController < ApplicationController
   end
 
   private
+
+  def resource_embeddable?(resource_params)
+    resource_params and
+    resource_params[:controller] == "documents" and
+    resource_params[:id] and
+    resource_params[:id] =~ DC::Validators::SLUG # and
+    # Document.accessible(nil, nil).exists?(params[:id].to_i) 
+  end
 
   def secure_silence_logs
     if params[:secure]

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -180,12 +180,12 @@ class ApiController < ApplicationController
     return not_found unless url.host == DC::CONFIG['server_root'] and resource_embeddable?(resource_params)
 
     # create a seralizer mock/class/struct for temporary use
-    resource_seralizer_klass = Struct.new(:id, :url)
+    resource_seralizer_klass = Struct.new(:id, :url, :type)
     resource_url = url_for(resource_params.merge(:format => 'js'))
-    resource = resource_seralizer_klass.new(resource_params[:id], resource_url)
+    resource = resource_seralizer_klass.new(resource_params[:id], resource_url, :document)
     
-    #config = pick(DC::Embed::DocumentOEmbed.config_keys, params)
-    embed = DC::Embed::Document.new(resource, {}, {:strategy => :oembed})
+    config = pick(params, DC::Embed.embed_klass(resource).config_keys)
+    embed = DC::Embed.embed_for(resource, config, {:strategy => :oembed})
     
     respond_to do |format|
       format.json do

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -176,7 +176,7 @@ class ApiController < ApplicationController
       return render :status => 400, :text => "Missing valid URL parameter"
     end
 
-    if url.host != DC::CONFIG['server_root']
+    unless url.host == DC::CONFIG['server_root'] # && Document.accessible(nil, nil).exists?(params[:id].to_i)
       return render :status => 404, :text => "Resource not found"
     end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -171,6 +171,11 @@ class ApiController < ApplicationController
   end
 
   def oembed
+    url = URI.parse(params[:url]) rescue nil
+    if params[:url].blank? || !url
+      return render :status => 400, :text => "Missing valid URL parameter"
+    end
+
     respond_to do |format|
       format.json do
         @response = {
@@ -188,6 +193,8 @@ class ApiController < ApplicationController
         json_response
       end
       format.all do
+        # As per the oEmbed spec, unrecognized formats should get a 501
+        # error.
         render :status => 501, :text => "Unsupported request type"
       end
     end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -201,22 +201,32 @@ class ApiController < ApplicationController
       :width            => params[:maxwidth] || nil,
     }
     embed_data = Hash[embed_data.reject { |k, v| v.nil? }]
-    embed_html = ERB.new(File.read("#{Rails.root}/app/views/documents/_embed_code.html.erb")).result(binding)
+    #embed_html = ERB.new(File.read("#{Rails.root}/app/views/documents/_embed_code.html.erb")).result(binding)
 
+    # create a seralizer mock/class/struct for temporary use
+    resource_seralizer_klass = Struct.new(:id, :url)
+    # get the numeric id for the resource.
+    resource_numeric_id = document_id.split("-").first
+    resource_url = url_for(resource_params.merge(:format => 'js'))
+    resource = resource_seralizer_klass.new(resource_numeric_id, resource_url)
+    
+    embed = DC::OEmbed.new(resource)
+    
     respond_to do |format|
       format.json do
-        @response = {
-          :type             => "rich",
-          :version          => "1.0",
-          :provider_name    => "DocumentCloud",
-          :provider_url     => DC.server_root,
-          :cache_age        => 300,
-          :resource_url     => nil,
-          :height           => params[:maxheight],
-          :width            => params[:maxwidth],
-          :display_language => nil,
-          :html             => embed_html,
-        }
+        #@response = {
+        #  :type             => "rich",
+        #  :version          => "1.0",
+        #  :provider_name    => "DocumentCloud",
+        #  :provider_url     => DC.server_root,
+        #  :cache_age        => 300,
+        #  :resource_url     => nil,
+        #  :height           => params[:maxheight],
+        #  :width            => params[:maxwidth],
+        #  :display_language => nil,
+        #  :html             => embed_html,
+        #}
+        @response = embed.as_json.to_json
         json_response
       end
       format.all do

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -171,7 +171,7 @@ class ApiController < ApplicationController
   end
 
   def oembed
-    url = URI.parse(params[:url]) rescue nil
+    url = URI.parse(CGI.unescape(params[:url])) rescue nil
     if params[:url].blank? || !url
       return render :status => 400, :text => "Missing valid URL parameter"
     end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -171,19 +171,26 @@ class ApiController < ApplicationController
   end
 
   def oembed
-    @response = {
-      :type             => "rich",
-      :version          => "1.0",
-      :provider_name    => "DocumentCloud",
-      :provider_url     => DC.server_root,
-      :cache_age        => 300,
-      :resource_url     => nil,
-      :height           => nil,
-      :width            => nil,
-      :display_language => nil,
-      :html             => nil,
-    }
-    json_response
+    respond_to do |format|
+      format.json do
+        @response = {
+          :type             => "rich",
+          :version          => "1.0",
+          :provider_name    => "DocumentCloud",
+          :provider_url     => DC.server_root,
+          :cache_age        => 300,
+          :resource_url     => nil,
+          :height           => nil,
+          :width            => nil,
+          :display_language => nil,
+          :html             => nil,
+        }
+        json_response
+      end
+      format.all do
+        render :status => 501, :text => "Unsupported request type"
+      end
+    end
   end
 
   def cors_options

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -185,6 +185,17 @@ class ApplicationController < ActionController::Base
     false
   end
 
+  # A resource was requested in a way we can't fulfill (e.g. an oEmbed
+  # request for XML when we only provide JSON)
+  def not_implemented
+    respond_to do |format|
+      format.js  { json({:error=>"Not Implemented"}, 501) }
+      format.json{ json({:error=>"Not Implemented"}, 501) }
+      format.any { render :file => "#{Rails.root}/public/501.html", :status => 501 }
+    end
+    false
+  end
+
   # Simple HTTP Basic Auth to make sure folks don't snoop where the shouldn't.
   def bouncer
     authenticate_or_request_with_http_basic("DocumentCloud") do |login, password|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -146,7 +146,11 @@ class ApplicationController < ActionController::Base
   end
 
   def bad_request
-    render :file => "#{Rails.root}/public/400.html", :status => 400
+    respond_to do |format|
+      format.js  { json({:error=>"Bad Request"}, 400) }
+      format.json{ json({:error=>"Bad Request"}, 400) }
+      format.any { render :file => "#{Rails.root}/public/400.html", :status => 400 }
+    end
     false
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,7 +12,7 @@ class Organization < ActiveRecord::Base
   has_many :documents
   validates :name, :slug, :presence=>true
   validates :name, :slug, :uniqueness=>true
-  validates :slug, :format => { :with => DC::Validators::SLUG }
+  validates :slug, :format => { :with => DC::Validators::SLUG_TEXT }
 
   validates :language, :inclusion=>{ :in => DC::Language::USER,
     :message => "must be one of: (#{DC::Language::USER.join(', ')})" }

--- a/app/views/documents/_embed_code.html.erb
+++ b/app/views/documents/_embed_code.html.erb
@@ -1,7 +1,6 @@
 <% if template_options[:use_default_container] %>
-  <div id="<%= template_options[:default_container_id] %>" class="DV-container"></div>
+<div id="<%= template_options[:default_container_id] %>" class="DV-container"></div>
 <% end %>
-<script src="//s3.amazonaws.com/s3.documentcloud.org/viewer/loader.js"></script>
 <script type="text/javascript">
   DV.load("<%= template_options[:resource_js_url] %>", {
     <%= embed_data.map{ |k,v| "'#{k}': '#{v}'"}.join(",\n") %>

--- a/app/views/documents/_embed_code.html.erb
+++ b/app/views/documents/_embed_code.html.erb
@@ -1,0 +1,12 @@
+<div id="DV-viewer-<%= doc.canonicalId() %>" class="DV-container"></div>
+<script src="//s3.amazonaws.com/s3.documentcloud.org/viewer/loader.js"></script>
+<script>
+  DV.load("<%= doc.get("document_viewer_js") %>", {
+  <%= options %>
+  });
+</script>
+  <% if (rawOptions.pdf !== false) { %><noscript>
+  <a href="<%= doc.publicUrl(doc.get('pdf_url')) %>"><%= doc.escape("title") %> (PDF)</a>
+  <br>
+  <a href="<%= doc.publicUrl(doc.get('full_text_url')) %>"><%= doc.escape("title") %> (Text)</a>
+</noscript><% } %>

--- a/app/views/documents/_embed_code.html.erb
+++ b/app/views/documents/_embed_code.html.erb
@@ -1,12 +1,16 @@
-<div id="DV-viewer-<%= doc.canonicalId() %>" class="DV-container"></div>
+<% if template_options[:use_default_container] %>
+  <div id="<%= template_options[:default_container_id] %>" class="DV-container"></div>
+<% end %>
 <script src="//s3.amazonaws.com/s3.documentcloud.org/viewer/loader.js"></script>
-<script>
-  DV.load("<%= doc.get("document_viewer_js") %>", {
-  <%= options %>
+<script type="text/javascript">
+  DV.load("<%= template_options[:resource_js_url] %>", {
+    <%= embed_data.map{ |k,v| "'#{k}': '#{v}'"}.join(",\n") %>
   });
 </script>
-  <% if (rawOptions.pdf !== false) { %><noscript>
-  <a href="<%= doc.publicUrl(doc.get('pdf_url')) %>"><%= doc.escape("title") %> (PDF)</a>
+<% if embed_data[:pdf] %>
+<noscript>
+  <a href="<%#= template_options[:pdf_url] %>"><%#= template_options[:title] %> (PDF)</a>
   <br>
-  <a href="<%= doc.publicUrl(doc.get('full_text_url')) %>"><%= doc.escape("title") %> (Text)</a>
-</noscript><% } %>
+  <a href="<%#= template_options[:full_text_url] %>"><%#= template_options[:title] %> (Text)</a>
+</noscript>
+<% end %>

--- a/app/views/documents/_embed_code.html.erb
+++ b/app/views/documents/_embed_code.html.erb
@@ -1,15 +1,15 @@
-<% if template_options[:use_default_container] %>
-<div id="<%= template_options[:default_container_id] %>" class="DV-container"></div>
+<% if options[:use_default_container] %>
+<div id="<%= options[:default_container_id] %>" class="DV-container"></div>
 <% end %>
 <script type="text/javascript">
-  DV.load("<%= template_options[:resource_js_url] %>", {
-    <%= embed_data.map{ |k,v| "'#{k}': '#{v}'"}.join(",\n") %>
+  DV.load("<%= options[:resource_js_url] %>", {
+    <%= data.map{ |k,v| "'#{k}': '#{v}'"}.join(",\n") %>
   });
 </script>
-<% if embed_data[:pdf] %>
+<% if data[:pdf] %>
 <noscript>
-  <a href="<%#= template_options[:pdf_url] %>"><%#= template_options[:title] %> (PDF)</a>
+  <a href="<%#= options[:pdf_url] %>"><%#= options[:title] %> (PDF)</a>
   <br>
-  <a href="<%#= template_options[:full_text_url] %>"><%#= template_options[:title] %> (Text)</a>
+  <a href="<%#= options[:full_text_url] %>"><%#= options[:title] %> (Text)</a>
 </noscript>
 <% end %>

--- a/app/views/documents/loader.js.erb
+++ b/app/views/documents/loader.js.erb
@@ -3,8 +3,8 @@
 %>
 
 (function() {
-  // If the viewer is already loaded, don't repeat the process.
-  if (window.DV && window.DV.loaded) return;
+  /* If the viewer is already loaded, don't repeat the process. */
+  if (window.DV) { if (window.DV.loaded) { return; } }
 
   window.DV = window.DV || {};
   window.DV.recordHit = "<%= DC.server_root(:agnostic=>true) %>/pixel.gif";
@@ -28,9 +28,9 @@
   @*/
   loadCSS('<%= asset_root %>/viewer/printviewer.css', 'print');
 
-  // Record the fact that the viewer is loaded.
+  /* Record the fact that the viewer is loaded. */
   DV.loaded = true;
 
-  // Request the viewer JavaScript.
-  document.write('<script type="text/javascript" src="<%= asset_root %>/viewer/viewer.js"></script>');
+  /* Request the viewer JavaScript. */
+  document.write('<script type="text/javascript" src="<%= asset_root %>/viewer/viewer.js"></scr' + 'ipt>');
 })();

--- a/app/views/documents/loader.js.erb
+++ b/app/views/documents/loader.js.erb
@@ -21,12 +21,12 @@
 
   /*@cc_on
   /*@if (@_jscript_version < 5.8)
-    loadCSS('<%= asset_root %>/viewer/viewer.css');
+    loadCSS("<%= asset_root %>/viewer/viewer.css");
   @else @*/
-    loadCSS('<%= asset_root %>/viewer/viewer-datauri.css');
+    loadCSS("<%= asset_root %>/viewer/viewer-datauri.css");
   /*@end
   @*/
-  loadCSS('<%= asset_root %>/viewer/printviewer.css', 'print');
+  loadCSS("<%= asset_root %>/viewer/printviewer.css", 'print');
 
   /* Record the fact that the viewer is loaded. */
   DV.loaded = true;

--- a/db/migrate/1_initial_migration.rb
+++ b/db/migrate/1_initial_migration.rb
@@ -25,12 +25,12 @@ class InitialMigration < ActiveRecord::Migration
     add_index "accounts", ["identities"], name: "index_accounts_on_identites", using: :gin
 
     create_table "annotations", force: true do |t|
-      t.integer  "organization_id",                null: false
-      t.integer  "account_id",                     null: false
-      t.integer  "document_id",                    null: false
-      t.integer  "page_number",                    null: false
-      t.integer  "access",                         null: false
-      t.text     "title",                          null: false
+      t.integer  "organization_id",     null: false
+      t.integer  "account_id",          null: false
+      t.integer  "document_id",         null: false
+      t.integer  "page_number",         null: false
+      t.integer  "access",              null: false
+      t.text     "title",               null: false
       t.text     "content"
       t.string   "location",            limit: 40
       t.datetime "created_at"
@@ -43,13 +43,6 @@ class InitialMigration < ActiveRecord::Migration
     create_table "app_constants", force: true do |t|
       t.string "key"
       t.string "value"
-    end
-
-    create_table "cloud_crowd_stats", force: true do |t|
-      t.tsrange "period"
-      t.integer "pending_count"
-      t.integer "average_wait"
-      t.integer "processing_count"
     end
 
     create_table "collaborations", force: true do |t|
@@ -104,7 +97,6 @@ class InitialMigration < ActiveRecord::Migration
     add_index "documents", ["account_id"], name: "index_documents_on_account_id", using: :btree
     add_index "documents", ["file_hash"], name: "index_documents_on_file_hash", using: :btree
     add_index "documents", ["hit_count"], name: "index_documents_on_hit_count", using: :btree
-    add_index "documents", ["organization_id"], name: "foo2", using: :btree
     add_index "documents", ["public_note_count"], name: "index_documents_on_public_note_count", using: :btree
 
     create_table "entities", force: true do |t|

--- a/lib/dc.rb
+++ b/lib/dc.rb
@@ -11,6 +11,7 @@ require 'dc/zip_utils'
 require 'dc/import'
 require 'dc/i18n'
 require 'dc/urls'
+require 'dc/embed'
 
 module DC
 end

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -53,9 +53,13 @@ module DC
     def template
       unless @template
         @template = ERB.new(File.read(@template_path))
-        #template.location = @template_path # uncomment this once deployed onto Ruby 2.2
+        #@template.location = @template_path # uncomment this once deployed onto Ruby 2.2
       end
       @template
+    end
+    
+    def render(data, options)
+      template.result(binding)
     end
     
     def content_markup
@@ -82,7 +86,7 @@ module DC
       }
       embed_data = Hash[embed_data.reject { |k, v| v.nil? }]
       
-      template.result(binding)
+      render(embed_data, template_options)
     end
     
     def bootstrap_markup

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -29,7 +29,7 @@ Embed strategy is the manner in which the embed code is introduced to the web pa
 =end
 module DC
   class Embed
-    attr_accessor :strategy, :dom_mechanism
+    attr_accessor :strategy, :dom_mechanism, :template
     attr_reader   :resource, :embed_config
     
     def initialize(resource, embed_config={}, options={})
@@ -45,6 +45,17 @@ module DC
       @embed_config  = embed_config
       @strategy      = options[:strategy]      || :server_side
       @dom_mechanism = options[:dom_mechanism] || :direct
+
+      @template_path = options[:template_path] || "#{Rails.root}/app/views/documents/_embed_code.html.erb"
+      @template      = options[:template]
+    end
+    
+    def template
+      unless @template
+        @template = ERB.new(File.read(@template_path))
+        #template.location = @template_path # uncomment this once deployed onto Ruby 2.2
+      end
+      @template
     end
     
     def content_markup
@@ -69,8 +80,8 @@ module DC
         :width            => @embed_config[:maxwidth]          || nil,
       }
       embed_data = Hash[embed_data.reject { |k, v| v.nil? }]
-
-      ERB.new(File.read("#{Rails.root}/app/views/documents/_embed_code.html.erb")).result(binding)
+      
+      template.result(binding)
     end
     
     def bootstrap_markup

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -19,12 +19,21 @@ The mechanism used for containing the contents of an embed.  Effectively there a
 * in-DOM (direct)
 * iFrame
 
-## Strategy
+## Embedding Context
 
-Embed strategy is the manner in which the embed code is introduced to the web page it has been instructed to load on (either contained in the markup sent to the browser, or inserted dynamically via javascript).
+Embedding context is the manner in which the embed code is introduced to the web page it 
+has been instructed to load on (either contained in the markup sent to the browser, or 
+inserted dynamically via javascript).
+
+The embedding context is generally not known to the embed generator.
 
 * Embedded in markup (server_side)
 * Client-side injection (client_side)
+
+## Request Strategy
+
+* oEmbed
+* Literal
 
 =end
 module DC

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -56,8 +56,8 @@ module DC
       ::Annotation => :note,
     }
     EMBEDDABLE_MODELS = EMBEDDABLE_MODEL_MAP.keys
-
-    def self.code(resource, config)
+    
+    def self.embed_for(resource, config={}, options={})
       resource_type = case
       when EMBEDDABLE_MODELS.any?{ |model_klass| resource.kind_of? model_klass }
         EMBEDDABLE_MODEL_MAP[resource.class]
@@ -67,8 +67,11 @@ module DC
         # set up a system to actually register types of things as embeddable
         raise ArgumentError, "#{resource} is not registered as an embeddable resource"
       end
-      embed_klass = EMBED_RESOURCE_MAP[resource_type]
-      embed_klass.new(resource, config).code
+      EMBED_RESOURCE_MAP[resource_type].new(resource,config, options)
+    end
+
+    def self.code(resource, config, options)
+      self.embed_for(resource, config, options).code
     end
     
     class Base

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -1,0 +1,82 @@
+=begin
+
+# Thoughts
+
+Embeds can be categorized along three dimensions:
+
+## Resource
+
+The resource is the type of thing you are embedding.  The contents of the embed will depend on the resource.  Each resource will include different code and configuration options (the literal contents of the embed). 
+
+* Documents
+* Notes
+* Search
+
+## DOM Mechanism
+
+The mechanism used for containing the contents of an embed.  Effectively there are two types of mechanisms: inserting a JS application directly into the embedding DOM, or inserting an iFrame which contains the contents of the embed.
+
+* in-DOM (direct)
+* iFrame
+
+## Strategy
+
+Embed strategy is the manner in which the embed code is introduced to the web page it has been instructed to load on (either contained in the markup sent to the browser, or inserted dynamically via javascript).
+
+* Embedded in markup (server_side)
+* Client-side injection (client_side)
+
+=end
+module DC
+  class Embed
+    attr_accessor :strategy, :dom_mechanism
+    attr_reader   :resource, :config
+    
+    def initialize(resource, config, options={})
+      @strategy      = options[:strategy]      || :server_side
+      @dom_mechanism = options[:dom_mechanism] || :direct
+      # resource should be a wrapper object around a model 
+      # which plucks out relevant metadata
+      # Consider ActiveModel::Serializers for this purpose.
+      # N.B. we should be able to generate oembed codes for things that are 
+      # basically mocks of a document, not just for real documents
+      raise ArgumentError unless resource.respond_to?(:id)
+      @resource      = resource
+      @config        = config # probably just a hash.
+    end
+    
+    def content_markup
+      template_options = {
+        :use_default_container => params[:container].blank? || params[:container].nil?,
+        :default_container_id  => "DV-viewer-#{@resource.id}",
+        :resource_js_url       => url_for(resource_params.merge(:format => 'js'))
+      }
+      embed_data = {
+        :container        => params[:container] || template_options[:default_container_id],
+        :zoom             => params[:zoom] || nil,
+        :search           => params[:search] || nil,
+        :showAnnotations  => params[:notes] || nil,
+        :sidebar          => params[:sidebar] || nil,
+        :text             => params[:text] || nil,
+        :pdf              => params[:pdf] || nil,
+        :responsive       => params[:responsive] || nil,
+        :responsiveOffset => params[:responsive_offset] || nil,
+        :page             => params[:default_page] || nil,
+        :note             => params[:default_note] || nil,
+        :height           => params[:maxheight] || nil,
+        :width            => params[:maxwidth] || nil,
+      }
+      embed_data = Hash[embed_data.reject { |k, v| v.nil? }]
+      ERB.new(File.read("#{Rails.root}/app/views/documents/_embed_code.html.erb")).result(binding)
+    end
+    
+    def bootstrap_markup
+      <<-BOOTSTRAP
+        <script src="//s3.amazonaws.com/s3.documentcloud.org/viewer/loader.js"></script>
+      BOOTSTRAP
+    end
+    
+    def code
+    end
+  end
+end

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -30,7 +30,7 @@ Embed strategy is the manner in which the embed code is introduced to the web pa
 module DC
   class Embed
     attr_accessor :strategy, :dom_mechanism
-    attr_reader   :resource, :config
+    attr_reader   :resource, :embed_config
     
     def initialize(resource, embed_config={}, options={})
       # resource should be a wrapper object around a model 
@@ -49,24 +49,24 @@ module DC
     
     def content_markup
       template_options = {
-        :use_default_container => @config[:container].nil? || @config[:container].empty?,
+        :use_default_container => @embed_config[:container].nil? || @embed_config[:container].empty?,
         :default_container_id  => "DV-viewer-#{@resource.id}",
         :resource_js_url       => @resource.url
       }
       embed_data = {
-        :container        => @config[:container]         || template_options[:default_container_id],
-        :zoom             => @config[:zoom]              || nil,
-        :search           => @config[:search]            || nil,
-        :showAnnotations  => @config[:notes]             || nil,
-        :sidebar          => @config[:sidebar]           || nil,
-        :text             => @config[:text]              || nil,
-        :pdf              => @config[:pdf]               || nil,
-        :responsive       => @config[:responsive]        || nil,
-        :responsiveOffset => @config[:responsive_offset] || nil,
-        :page             => @config[:default_page]      || nil,
-        :note             => @config[:default_note]      || nil,
-        :height           => @config[:maxheight]         || nil,
-        :width            => @config[:maxwidth]          || nil,
+        :container        => @embed_config[:container]         || template_options[:default_container_id],
+        :zoom             => @embed_config[:zoom]              || nil,
+        :search           => @embed_config[:search]            || nil,
+        :showAnnotations  => @embed_config[:notes]             || nil,
+        :sidebar          => @embed_config[:sidebar]           || nil,
+        :text             => @embed_config[:text]              || nil,
+        :pdf              => @embed_config[:pdf]               || nil,
+        :responsive       => @embed_config[:responsive]        || nil,
+        :responsiveOffset => @embed_config[:responsive_offset] || nil,
+        :page             => @embed_config[:default_page]      || nil,
+        :note             => @embed_config[:default_note]      || nil,
+        :height           => @embed_config[:maxheight]         || nil,
+        :width            => @embed_config[:maxwidth]          || nil,
       }
       embed_data = Hash[embed_data.reject { |k, v| v.nil? }]
 

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -38,7 +38,9 @@ module DC
       # Consider ActiveModel::Serializers for this purpose.
       # N.B. we should be able to generate oembed codes for things that are 
       # basically mocks of a document, not just for real documents
-      raise ArgumentError unless resource.respond_to?(:id)
+      [:id, :url].each do |attribute| 
+        raise ArgumentError, "Embed resource must `respond_to?` an ':#{attribute}' attribute" unless resource.respond_to?(attribute)
+      end
       @resource      = resource
       @config        = config # probably just a hash.
       @strategy      = options[:strategy]      || :server_side

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -33,8 +33,6 @@ module DC
     attr_reader   :resource, :config
     
     def initialize(resource, config, options={})
-      @strategy      = options[:strategy]      || :server_side
-      @dom_mechanism = options[:dom_mechanism] || :direct
       # resource should be a wrapper object around a model 
       # which plucks out relevant metadata
       # Consider ActiveModel::Serializers for this purpose.
@@ -43,6 +41,8 @@ module DC
       raise ArgumentError unless resource.respond_to?(:id)
       @resource      = resource
       @config        = config # probably just a hash.
+      @strategy      = options[:strategy]      || :server_side
+      @dom_mechanism = options[:dom_mechanism] || :direct
     end
     
     def content_markup
@@ -52,31 +52,31 @@ module DC
         :resource_js_url       => url_for(resource_params.merge(:format => 'js'))
       }
       embed_data = {
-        :container        => params[:container] || template_options[:default_container_id],
-        :zoom             => params[:zoom] || nil,
-        :search           => params[:search] || nil,
-        :showAnnotations  => params[:notes] || nil,
-        :sidebar          => params[:sidebar] || nil,
-        :text             => params[:text] || nil,
-        :pdf              => params[:pdf] || nil,
-        :responsive       => params[:responsive] || nil,
+        :container        => params[:container]         || template_options[:default_container_id],
+        :zoom             => params[:zoom]              || nil,
+        :search           => params[:search]            || nil,
+        :showAnnotations  => params[:notes]             || nil,
+        :sidebar          => params[:sidebar]           || nil,
+        :text             => params[:text]              || nil,
+        :pdf              => params[:pdf]               || nil,
+        :responsive       => params[:responsive]        || nil,
         :responsiveOffset => params[:responsive_offset] || nil,
-        :page             => params[:default_page] || nil,
-        :note             => params[:default_note] || nil,
-        :height           => params[:maxheight] || nil,
-        :width            => params[:maxwidth] || nil,
+        :page             => params[:default_page]      || nil,
+        :note             => params[:default_note]      || nil,
+        :height           => params[:maxheight]         || nil,
+        :width            => params[:maxwidth]          || nil,
       }
       embed_data = Hash[embed_data.reject { |k, v| v.nil? }]
+
       ERB.new(File.read("#{Rails.root}/app/views/documents/_embed_code.html.erb")).result(binding)
     end
     
     def bootstrap_markup
-      <<-BOOTSTRAP
-        <script src="//s3.amazonaws.com/s3.documentcloud.org/viewer/loader.js"></script>
-      BOOTSTRAP
+      '<script src="//s3.amazonaws.com/s3.documentcloud.org/viewer/loader.js"></script>'
     end
     
     def code
+      [bootstrap_markup, content_markup].join("\n")
     end
   end
 end

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -28,97 +28,163 @@ Embed strategy is the manner in which the embed code is introduced to the web pa
 
 =end
 module DC
-  class Embed
-    attr_accessor :strategy, :dom_mechanism, :template
-    attr_reader   :resource, :embed_config
+  module Embed
     
-    def initialize(resource, embed_config={}, options={})
-      # resource should be a wrapper object around a model 
-      # which plucks out relevant metadata
-      # Consider ActiveModel::Serializers for this purpose.
-      # N.B. we should be able to generate oembed codes for things that are 
-      # basically mocks of a document, not just for real documents
-      [:id, :url].each do |attribute| 
-        raise ArgumentError, "Embed resource must `respond_to?` an ':#{attribute}' attribute" unless resource.respond_to?(attribute)
-      end
-      @resource      = resource
-      @embed_config  = embed_config
-      @strategy      = options[:strategy]      || :server_side
-      @dom_mechanism = options[:dom_mechanism] || :direct
+    # lol forward declaration
+    class Base; end
+    class Document < Base; end
+    class Note < Base; end
+    class Search < Base; end
+    EMBED_RESOURCE_MAP = {
+      :document => self::Document,
+      :note     => self::Note,
+      :search   => self::Search,
+    }
+    EMBEDDABLE_RESOURCES = EMBED_RESOURCE_MAP.keys
+    
+    EMBEDDABLE_MODEL_MAP = {
+      ::Document   => :document,
+      ::Annotation => :note,
+    }
+    EMBEDDABLE_MODELS = EMBEDDABLE_MODEL_MAP.keys
 
-      @template_path = options[:template_path] || "#{Rails.root}/app/views/documents/_embed_code.html.erb"
-      @template      = options[:template]
-    end
-    
-    def template
-      unless @template
-        @template = ERB.new(File.read(@template_path))
-        #@template.location = @template_path # uncomment this once deployed onto Ruby 2.2
+    def self.code(resource, config)
+      resource_type = case
+      when EMBEDDABLE_MODELS.any?{ |model_klass| resource.kind_of? model_klass }
+        EMBEDDABLE_MODEL_MAP[resource.class]
+      when EMBEDDABLE_RESOURCES.any?{ |embeddable_resource| resource.type == embeddable_resource }
+        resource.type
+      else
+        # set up a system to actually register types of things as embeddable
+        raise ArgumentError, "#{resource} is not registered as an embeddable resource"
       end
-      @template
+      embed_klass = EMBED_RESOURCE_MAP[resource_type]
+      embed_klass.new(resource, config).code
     end
     
-    def render(data, options)
-      template.result(binding)
-    end
-    
-    def content_markup
-      template_options = {
-        :use_default_container => @embed_config[:container].nil? || @embed_config[:container].empty?,
-        :default_container_id  => "DV-viewer-#{@resource.id}",
-        :resource_js_url       => @resource.url
-      }
-      embed_data = {
-        :container        => '#' + (@embed_config[:container]  || template_options[:default_container_id]),
-        :showAnnotations  => @embed_config[:notes]             || nil,
-        :responsiveOffset => @embed_config[:responsive_offset] || nil,
-        :page             => @embed_config[:default_page]      || nil,
-        :note             => @embed_config[:default_note]      || nil,
-        :height           => @embed_config[:maxheight]         || nil,
-        :width            => @embed_config[:maxwidth]          || nil,
-        # all of the options below are passthrough.
-        :zoom             => @embed_config[:zoom]              || nil,
-        :search           => @embed_config[:search]            || nil,
-        :sidebar          => @embed_config[:sidebar]           || nil,
-        :text             => @embed_config[:text]              || nil,
-        :pdf              => @embed_config[:pdf]               || nil,
-        :responsive       => @embed_config[:responsive]        || nil,
-      }
-      embed_data = Hash[embed_data.reject { |k, v| v.nil? }]
+    class Base
+      attr_accessor :strategy, :dom_mechanism, :template
+      attr_reader   :resource, :embed_config
       
-      render(embed_data, template_options)
+      def initialize(*args)
+        raise NotImplementedError
+      end
+    
+      def bootstrap_markup
+        raise NotImplementedError
+      end
+      
+      def content_markup
+        raise NotImplementedError
+      end
+      
+      def code
+        [bootstrap_markup, content_markup].join("\n")
+      end
+      
+      private
+      def content_template
+        raise NotImplementedError
+      end
+      
+      def bootstrap_template
+        raise NotImplementedError
+      end
+      
+      def render(template, data, options)
+        raise NotImplementedError
+      end
     end
     
-    def bootstrap_markup
-      '<script src="//s3.amazonaws.com/s3.documentcloud.org/viewer/loader.js"></script>'
-    end
+    class Document < Base
+      def initialize(resource, embed_config={}, options={})
+        # resource should be a wrapper object around a model 
+        # which plucks out relevant metadata
+        # Consider ActiveModel::Serializers for this purpose.
+        # N.B. we should be able to generate oembed codes for things that are 
+        # basically mocks of a document, not just for real documents
+        [:id, :url].each do |attribute| 
+          raise ArgumentError, "Embed resource must `respond_to?` an ':#{attribute}' attribute" unless resource.respond_to?(attribute)
+        end
+        @resource      = resource
+        @embed_config  = embed_config
+        @strategy      = options[:strategy]      || :server_side
+        @dom_mechanism = options[:dom_mechanism] || :direct
+
+        @template_path = options[:template_path] || "#{Rails.root}/app/views/documents/_embed_code.html.erb"
+        @template      = options[:template]
+      end
     
-    def code
-      [bootstrap_markup, content_markup].join("\n")
+      def template
+        unless @template
+          @template = ERB.new(File.read(@template_path))
+          #@template.location = @template_path # uncomment this once deployed onto Ruby 2.2
+        end
+        @template
+      end
+    
+      def render(data, options)
+        template.result(binding)
+      end
+    
+      def content_markup
+        template_options = {
+          :use_default_container => @embed_config[:container].nil? || @embed_config[:container].empty?,
+          :default_container_id  => "DV-viewer-#{@resource.id}",
+          :resource_js_url       => @resource.url
+        }
+        embed_data = {
+          :container        => '#' + (@embed_config[:container]  || template_options[:default_container_id]),
+          :showAnnotations  => @embed_config[:notes]             || nil,
+          :responsiveOffset => @embed_config[:responsive_offset] || nil,
+          :page             => @embed_config[:default_page]      || nil,
+          :note             => @embed_config[:default_note]      || nil,
+          :height           => @embed_config[:maxheight]         || nil,
+          :width            => @embed_config[:maxwidth]          || nil,
+          # all of the options below are passthrough.
+          :zoom             => @embed_config[:zoom]              || nil,
+          :search           => @embed_config[:search]            || nil,
+          :sidebar          => @embed_config[:sidebar]           || nil,
+          :text             => @embed_config[:text]              || nil,
+          :pdf              => @embed_config[:pdf]               || nil,
+          :responsive       => @embed_config[:responsive]        || nil,
+        }
+        embed_data = Hash[embed_data.reject { |k, v| v.nil? }]
+      
+        render(embed_data, template_options)
+      end
+    
+      def bootstrap_markup
+        '<script src="//s3.amazonaws.com/s3.documentcloud.org/viewer/loader.js"></script>'
+      end
+    
+      def code
+        [bootstrap_markup, content_markup].join("\n")
+      end
     end
-  end
   
-  class OEmbed < Embed
-    def bootstrap_markup
-      @bootstrap_template_path = "#{Rails.root}/app/views/documents/loader.js.erb"
-      @bootstrap_template = ERB.new(File.read(@bootstrap_template_path))
-      #@template.location = @template_path # uncomment this once deployed onto Ruby 2.2
-      "<script>#{@bootstrap_template.result(binding)}</script>"
-    end
+    class DocumentOEmbed < Document
+      def bootstrap_markup
+        @bootstrap_template_path = "#{Rails.root}/app/views/documents/loader.js.erb"
+        @bootstrap_template = ERB.new(File.read(@bootstrap_template_path))
+        #@template.location = @template_path # uncomment this once deployed onto Ruby 2.2
+        "<script>#{@bootstrap_template.result(binding)}</script>"
+      end
     
-    def as_json
-      {
-        :type             => "rich",
-        :version          => "1.0",
-        :provider_name    => "DocumentCloud",
-        :provider_url     => DC.server_root,
-        :cache_age        => 300,
-        :resource_url     => nil,
-        :height           => @embed_config[:maxheight],
-        :width            => @embed_config[:maxwidth],
-        :display_language => nil,
-        :html             => code,
-      }
+      def as_json
+        {
+          :type             => "rich",
+          :version          => "1.0",
+          :provider_name    => "DocumentCloud",
+          :provider_url     => DC.server_root,
+          :cache_age        => 300,
+          :resource_url     => nil,
+          :height           => @embed_config[:maxheight],
+          :width            => @embed_config[:maxwidth],
+          :display_language => nil,
+          :html             => code,
+        }
+      end
     end
   end
 end

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -97,4 +97,28 @@ module DC
       [bootstrap_markup, content_markup].join("\n")
     end
   end
+  
+  class OEmbed < Embed
+    def bootstrap_markup
+      @bootstrap_template_path = "#{Rails.root}/app/views/documents/loader.js.erb"
+      @bootstrap_template = ERB.new(File.read(@bootstrap_template_path))
+      #@template.location = @template_path # uncomment this once deployed onto Ruby 2.2
+      "<script>#{@bootstrap_template.result(binding)}</script>"
+    end
+    
+    def as_json
+      {
+        :type             => "rich",
+        :version          => "1.0",
+        :provider_name    => "DocumentCloud",
+        :provider_url     => DC.server_root,
+        :cache_age        => 300,
+        :resource_url     => nil,
+        :height           => @embed_config[:maxheight],
+        :width            => @embed_config[:maxwidth],
+        :display_language => nil,
+        :html             => code,
+      }
+    end
+  end
 end

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -47,7 +47,7 @@ module DC
     
     def content_markup
       template_options = {
-        :use_default_container => params[:container].blank? || params[:container].nil?,
+        :use_default_container => @config[:container].nil? || @config[:container].empty?,
         :default_container_id  => "DV-viewer-#{@resource.id}",
         :resource_js_url       => url_for(resource_params.merge(:format => 'js'))
       }

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -70,6 +70,7 @@ module DC
     end
     
     def self.embed_klass(type)
+      raise ArgumentError, "#{type} is not a recognized resource type" unless EMBEDDABLE_RESOURCES.include? type
       EMBED_RESOURCE_MAP[type]
     end
     
@@ -161,19 +162,19 @@ module DC
         }
         embed_data = {
           :container        => '#' + (@embed_config[:container]  || template_options[:default_container_id]),
-          :showAnnotations  => @embed_config[:notes]             || nil,
-          :responsiveOffset => @embed_config[:responsive_offset] || nil,
-          :page             => @embed_config[:default_page]      || nil,
-          :note             => @embed_config[:default_note]      || nil,
-          :height           => @embed_config[:maxheight]         || nil,
-          :width            => @embed_config[:maxwidth]          || nil,
+          :showAnnotations  => @embed_config.fetch(:notes,              nil),
+          :responsiveOffset => @embed_config.fetch(:responsive_offset,  nil),
+          :page             => @embed_config.fetch(:default_page,       nil),
+          :note             => @embed_config.fetch(:default_note,       nil),
+          :height           => @embed_config.fetch(:maxheight,          nil),
+          :width            => @embed_config.fetch(:maxwidth,           nil),
           # all of the options below are passthrough.
-          :zoom             => @embed_config[:zoom]              || nil,
-          :search           => @embed_config[:search]            || nil,
-          :sidebar          => @embed_config[:sidebar]           || nil,
-          :text             => @embed_config[:text]              || nil,
-          :pdf              => @embed_config[:pdf]               || nil,
-          :responsive       => @embed_config[:responsive]        || nil,
+          :zoom             => @embed_config.fetch(:zoom,       nil),
+          :search           => @embed_config.fetch(:search,     nil),
+          :sidebar          => @embed_config.fetch(:sidebar,    nil),
+          :text             => @embed_config.fetch(:text,       nil),
+          :pdf              => @embed_config.fetch(:pdf,        nil),
+          :responsive       => @embed_config.fetch(:responsive, nil),
         }
         embed_data = Hash[embed_data.reject { |k, v| v.nil? }]
       

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -32,7 +32,7 @@ module DC
     attr_accessor :strategy, :dom_mechanism
     attr_reader   :resource, :config
     
-    def initialize(resource, config, options={})
+    def initialize(resource, embed_config={}, options={})
       # resource should be a wrapper object around a model 
       # which plucks out relevant metadata
       # Consider ActiveModel::Serializers for this purpose.
@@ -42,7 +42,7 @@ module DC
         raise ArgumentError, "Embed resource must `respond_to?` an ':#{attribute}' attribute" unless resource.respond_to?(attribute)
       end
       @resource      = resource
-      @config        = config # probably just a hash.
+      @embed_config  = embed_config
       @strategy      = options[:strategy]      || :server_side
       @dom_mechanism = options[:dom_mechanism] || :direct
     end
@@ -51,22 +51,22 @@ module DC
       template_options = {
         :use_default_container => @config[:container].nil? || @config[:container].empty?,
         :default_container_id  => "DV-viewer-#{@resource.id}",
-        :resource_js_url       => url_for(resource_params.merge(:format => 'js'))
+        :resource_js_url       => @resource.url
       }
       embed_data = {
-        :container        => params[:container]         || template_options[:default_container_id],
-        :zoom             => params[:zoom]              || nil,
-        :search           => params[:search]            || nil,
-        :showAnnotations  => params[:notes]             || nil,
-        :sidebar          => params[:sidebar]           || nil,
-        :text             => params[:text]              || nil,
-        :pdf              => params[:pdf]               || nil,
-        :responsive       => params[:responsive]        || nil,
-        :responsiveOffset => params[:responsive_offset] || nil,
-        :page             => params[:default_page]      || nil,
-        :note             => params[:default_note]      || nil,
-        :height           => params[:maxheight]         || nil,
-        :width            => params[:maxwidth]          || nil,
+        :container        => @config[:container]         || template_options[:default_container_id],
+        :zoom             => @config[:zoom]              || nil,
+        :search           => @config[:search]            || nil,
+        :showAnnotations  => @config[:notes]             || nil,
+        :sidebar          => @config[:sidebar]           || nil,
+        :text             => @config[:text]              || nil,
+        :pdf              => @config[:pdf]               || nil,
+        :responsive       => @config[:responsive]        || nil,
+        :responsiveOffset => @config[:responsive_offset] || nil,
+        :page             => @config[:default_page]      || nil,
+        :note             => @config[:default_note]      || nil,
+        :height           => @config[:maxheight]         || nil,
+        :width            => @config[:maxwidth]          || nil,
       }
       embed_data = Hash[embed_data.reject { |k, v| v.nil? }]
 

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -69,7 +69,7 @@ module DC
         :resource_js_url       => @resource.url
       }
       embed_data = {
-        :container        => @embed_config[:container]         || template_options[:default_container_id],
+        :container        => '#' + (@embed_config[:container]  || template_options[:default_container_id]),
         :showAnnotations  => @embed_config[:notes]             || nil,
         :responsiveOffset => @embed_config[:responsive_offset] || nil,
         :page             => @embed_config[:default_page]      || nil,

--- a/lib/dc/embed.rb
+++ b/lib/dc/embed.rb
@@ -66,18 +66,19 @@ module DC
       }
       embed_data = {
         :container        => @embed_config[:container]         || template_options[:default_container_id],
-        :zoom             => @embed_config[:zoom]              || nil,
-        :search           => @embed_config[:search]            || nil,
         :showAnnotations  => @embed_config[:notes]             || nil,
-        :sidebar          => @embed_config[:sidebar]           || nil,
-        :text             => @embed_config[:text]              || nil,
-        :pdf              => @embed_config[:pdf]               || nil,
-        :responsive       => @embed_config[:responsive]        || nil,
         :responsiveOffset => @embed_config[:responsive_offset] || nil,
         :page             => @embed_config[:default_page]      || nil,
         :note             => @embed_config[:default_note]      || nil,
         :height           => @embed_config[:maxheight]         || nil,
         :width            => @embed_config[:maxwidth]          || nil,
+        # all of the options below are passthrough.
+        :zoom             => @embed_config[:zoom]              || nil,
+        :search           => @embed_config[:search]            || nil,
+        :sidebar          => @embed_config[:sidebar]           || nil,
+        :text             => @embed_config[:text]              || nil,
+        :pdf              => @embed_config[:pdf]               || nil,
+        :responsive       => @embed_config[:responsive]        || nil,
       }
       embed_data = Hash[embed_data.reject { |k, v| v.nil? }]
       

--- a/lib/dc/validators.rb
+++ b/lib/dc/validators.rb
@@ -9,7 +9,11 @@ module DC
     SUBDOMAIN = /\A[0-9a-z\-_]+\Z/i
 
     # Proper slugs are alphanumeric, lowercased, with dashes.
-    SLUG = /\A[a-z0-9\-]+\Z/
+    SLUG_TEXT = /\A[a-z0-9\-]+\Z/
+
+    # Full document ID slugs must start with the numeric ID and contain
+    # the alphanumeric slug
+    SLUG = /\A[0-9]+-[a-z0-9-]+\Z/
 
     # IP Validation Regex.
     IP = /\A(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\Z/

--- a/public/501.html
+++ b/public/501.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="chrome=1">
+  <title>Not Implemented - DocumentCloud</title>
+  
+  <link href="/stylesheets/common/reset.css" media="all" rel="stylesheet" type="text/css" />
+  <link href="/stylesheets/ui/ui.css" media="all" rel="stylesheet" type="text/css" />
+  <link href="/stylesheets/pages/workspace.css" media="all" rel="stylesheet" type="text/css" />
+</head>
+<body class="full_page_background">
+
+  <div id="container">
+    <div id="topbar" class="header gradient_mid">
+      <div id="cloud_edge"></div>
+      <div id="wordmark" class="logo_words"><a href="/">DocumentCloud</a></div>
+      <h1 id="title" class="logo_words">501 Not Implemented</h1>
+    </div>
+
+    <div id="content">
+      <div class="full_page_background">
+        <div class="static_error">
+          The server can't fulfill the request.
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -28,7 +28,6 @@ class ApiControllerTest < ActionController::TestCase
     assert_recognizes(
       { controller: 'api', action: 'cors_options', :format=>'json', "allowed_methods"=>[:get] },
       { path: '/api/search.json',  method: :options } )
-
   end
 
   def test_index
@@ -50,8 +49,7 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal ["Accept", "Authorization", "Content-Length", "Content-Type", "Cookie"], cors_allowed_headers.sort
   end
 
-
-  def test_search
+  def test_empty_search_results
     get :search, q: 'ponies', :format => :json
     assert_has_search_params Sunspot.session.searches.last, :keywords, 'ponies'
     assert_equal 0, json_body['total']

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -179,9 +179,4 @@ class ApiControllerTest < ActionController::TestCase
     assert_raises( ActiveRecord::RecordNotFound ){ Project.find( project.id ) }
   end
 
-  def test_oembed_response
-    get :oembed
-    assert_response :success
-  end
-
 end

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -179,4 +179,9 @@ class ApiControllerTest < ActionController::TestCase
     assert_raises( ActiveRecord::RecordNotFound ){ Project.find( project.id ) }
   end
 
+  def test_oembed_response
+    get :oembed
+    assert_response :success
+  end
+
 end

--- a/test/controllers/oembed_controller_test.rb
+++ b/test/controllers/oembed_controller_test.rb
@@ -8,6 +8,7 @@ class OembedControllerTest < ActionController::TestCase
   default_url_options[:host] = DC::CONFIG['server_root']
 
   let(:valid_resource_url) { CGI.escape(url_for :controller => 'documents', :action => 'show', :id => '1-is-the-lonelist-number', :format => 'html') }
+  let(:unsupported_resource_url) { CGI.escape(url_for :controller => 'home', :action => 'index') }
 
   def test_oembed_response
     get :oembed, :format => "json", :url => valid_resource_url
@@ -29,6 +30,11 @@ class OembedControllerTest < ActionController::TestCase
 
   def test_wrong_domain
     get :oembed, :format => "json", :url => CGI.escape("http://www.apple.com")
+    assert_response 404
+  end
+
+  def test_unsupported_resource
+    get :oembed, :format => "json", :url => unsupported_resource_url
     assert_response 404
   end
 

--- a/test/controllers/oembed_controller_test.rb
+++ b/test/controllers/oembed_controller_test.rb
@@ -4,8 +4,12 @@ class OembedControllerTest < ActionController::TestCase
   
   tests ApiController
 
+  include Rails.application.routes.url_helpers
+  default_url_options[:host] = DC::CONFIG['server_root']
+
   def test_oembed_response
-    get :oembed, :format => "json", :url => CGI.escape("https://www.documentcloud.org/help")
+    url = CGI.escape(url_for :controller => 'workspace', :action => 'help')
+    get :oembed, :format => "json", :url => url
     assert_response :success
     assert_equal 'rich', json_body['type']
     assert_equal '1.0', json_body['version']
@@ -18,7 +22,8 @@ class OembedControllerTest < ActionController::TestCase
   end
 
   def test_unsupported_format
-    get :oembed, :format => "lol", :url => CGI.escape("https://www.documentcloud.org/help")
+    url = CGI.escape(url_for :controller => 'workspace', :action => 'help')
+    get :oembed, :format => "lol", :url => url
     assert_response 501
   end
 

--- a/test/controllers/oembed_controller_test.rb
+++ b/test/controllers/oembed_controller_test.rb
@@ -7,9 +7,10 @@ class OembedControllerTest < ActionController::TestCase
   include Rails.application.routes.url_helpers
   default_url_options[:host] = DC::CONFIG['server_root']
 
+  let(:valid_resource_url) { CGI.escape(url_for :controller => 'documents', :action => 'show', :id => '1-is-the-lonelist-number', :format => 'html') }
+
   def test_oembed_response
-    url = CGI.escape(url_for :controller => 'workspace', :action => 'help')
-    get :oembed, :format => "json", :url => url
+    get :oembed, :format => "json", :url => valid_resource_url
     assert_response :success
     assert_equal 'rich', json_body['type']
     assert_equal '1.0', json_body['version']
@@ -22,13 +23,19 @@ class OembedControllerTest < ActionController::TestCase
   end
 
   def test_unsupported_format
-    url = CGI.escape(url_for :controller => 'workspace', :action => 'help')
-    get :oembed, :format => "lol", :url => url
+    get :oembed, :format => "lol", :url => valid_resource_url
     assert_response 501
   end
 
   def test_wrong_domain
     get :oembed, :format => "json", :url => CGI.escape("http://www.apple.com")
+    assert_response 404
+  end
+
+  def test_missing_resource
+    skip "Not yet implemented missing resource check"
+    missing_resource_url = CGI.escape(url_for :controller => 'documents', :action => 'show', :id => '1-is-the-lonelist-number', :format => 'html')
+    get :oembed, :format => "json", :url => missing_resource_url
     assert_response 404
   end
 

--- a/test/controllers/oembed_controller_test.rb
+++ b/test/controllers/oembed_controller_test.rb
@@ -12,7 +12,7 @@ class OembedControllerTest < ActionController::TestCase
     assert_equal DC.server_root, json_body['provider_url']
   end
 
-  def test_unsupport_format
+  def test_unsupported_format
     get :oembed, :format => "lol"
     assert_response 501
   end

--- a/test/controllers/oembed_controller_test.rb
+++ b/test/controllers/oembed_controller_test.rb
@@ -5,15 +5,20 @@ class OembedControllerTest < ActionController::TestCase
   tests ApiController
 
   def test_oembed_response
-    get :oembed, :format => "json"
+    get :oembed, :format => "json", :url => CGI.escape("https://www.documentcloud.org/help")
     assert_response :success
     assert_equal 'rich', json_body['type']
     assert_equal '1.0', json_body['version']
     assert_equal DC.server_root, json_body['provider_url']
   end
 
+  def test_missing_url_param
+    get :oembed, :format => "json"
+    assert_response 400
+  end
+
   def test_unsupported_format
-    get :oembed, :format => "lol"
+    get :oembed, :format => "lol", :url => CGI.escape("https://www.documentcloud.org/help")
     assert_response 501
   end
 

--- a/test/controllers/oembed_controller_test.rb
+++ b/test/controllers/oembed_controller_test.rb
@@ -8,7 +8,9 @@ class OembedControllerTest < ActionController::TestCase
   default_url_options[:host] = DC::CONFIG['server_root']
 
   let(:valid_resource_url) { CGI.escape(url_for :controller => 'documents', :action => 'show', :id => '1-is-the-lonelist-number', :format => 'html') }
+  let(:missing_resource_url) { CGI.escape(url_for :controller => 'documents', :action => 'show', :id => '3-the-magic-number', :format => 'html') }
   let(:unsupported_resource_url) { CGI.escape(url_for :controller => 'home', :action => 'index') }
+  let(:external_resource_url) { CGI.escape('http://www2.warnerbros.com/spacejam/movie/jam.htm') }
 
   def test_oembed_response
     get :oembed, :format => "json", :url => valid_resource_url
@@ -29,7 +31,7 @@ class OembedControllerTest < ActionController::TestCase
   end
 
   def test_wrong_domain
-    get :oembed, :format => "json", :url => CGI.escape("http://www.apple.com")
+    get :oembed, :format => "json", :url => external_resource_url
     assert_response 404
   end
 
@@ -40,7 +42,6 @@ class OembedControllerTest < ActionController::TestCase
 
   def test_missing_resource
     skip "Not yet implemented missing resource check"
-    missing_resource_url = CGI.escape(url_for :controller => 'documents', :action => 'show', :id => '1-is-the-lonelist-number', :format => 'html')
     get :oembed, :format => "json", :url => missing_resource_url
     assert_response 404
   end

--- a/test/controllers/oembed_controller_test.rb
+++ b/test/controllers/oembed_controller_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class OembedControllerTest < ActionController::TestCase
+  
+  tests ApiController
+
+  def test_oembed_response
+    get :oembed
+    assert_response :success
+    assert_equal 'rich', json_body['type']
+    assert_equal '1.0', json_body['version']
+    assert_equal DC.server_root, json_body['provider_url']
+  end
+
+end

--- a/test/controllers/oembed_controller_test.rb
+++ b/test/controllers/oembed_controller_test.rb
@@ -46,4 +46,10 @@ class OembedControllerTest < ActionController::TestCase
     assert_response 404
   end
 
+  def test_blank_container
+    get :oembed, :format => "json", :url => valid_resource_url, :container => ''
+    template_options = assigns(:template_options)
+    assert template_options[:use_default_container]
+  end
+
 end

--- a/test/controllers/oembed_controller_test.rb
+++ b/test/controllers/oembed_controller_test.rb
@@ -5,11 +5,16 @@ class OembedControllerTest < ActionController::TestCase
   tests ApiController
 
   def test_oembed_response
-    get :oembed
+    get :oembed, :format => "json"
     assert_response :success
     assert_equal 'rich', json_body['type']
     assert_equal '1.0', json_body['version']
     assert_equal DC.server_root, json_body['provider_url']
+  end
+
+  def test_unsupport_format
+    get :oembed, :format => "lol"
+    assert_response 501
   end
 
 end

--- a/test/controllers/oembed_controller_test.rb
+++ b/test/controllers/oembed_controller_test.rb
@@ -27,4 +27,9 @@ class OembedControllerTest < ActionController::TestCase
     assert_response 501
   end
 
+  def test_wrong_domain
+    get :oembed, :format => "json", :url => CGI.escape("http://www.apple.com")
+    assert_response 404
+  end
+
 end

--- a/test/lib/embed_test.rb
+++ b/test/lib/embed_test.rb
@@ -27,4 +27,13 @@ describe DC::Embed::Document do
 
   it "should output an oembed response as json"
   it "should output a JST template"
+
+  it "should configure embed code based on config settings" do
+    config = {
+      :sidebar => false
+    }
+    embed = DC::Embed::Document.new(resource, config)
+    embed.embed_config[:sidebar].must_equal false
+    embed.code.must_match /sidebar/
+  end
 end

--- a/test/lib/embed_test.rb
+++ b/test/lib/embed_test.rb
@@ -1,0 +1,11 @@
+require_relative '../test_helper'
+
+describe DC::Embed do
+  it "should require a resource" do
+    Proc.new{ DC::Embed.new(nil, {}) }.must_raise ArgumentError
+    Proc.new{ DC::Embed.new({}, {})  }.must_raise ArgumentError
+
+    struct = Struct.new(:id).new
+    DC::Embed.new(struct, {}).must_be_kind_of DC::Embed
+  end
+end

--- a/test/lib/embed_test.rb
+++ b/test/lib/embed_test.rb
@@ -1,19 +1,19 @@
 require_relative '../test_helper'
 require 'pry'
 
-describe DC::Embed do
+describe DC::Embed::Document do
   
   let(:resource) { Struct.new(:id, :url).new("1235", "https://lol.wat/1235") }
   
   it "should require a resource" do
-    Proc.new{ DC::Embed.new(nil, {}) }.must_raise ArgumentError
-    Proc.new{ DC::Embed.new({}, {})  }.must_raise ArgumentError
+    Proc.new{ DC::Embed::Document.new(nil, {}) }.must_raise ArgumentError
+    Proc.new{ DC::Embed::Document.new({}, {})  }.must_raise ArgumentError
 
-    DC::Embed.new(resource, {}).must_be_kind_of DC::Embed
+    DC::Embed::Document.new(resource, {}).must_be_kind_of DC::Embed::Document
   end
   
   it "should output HTML markup" do
-    embed_code = Nokogiri::HTML(DC::Embed.new(resource, {}).code)
+    embed_code = Nokogiri::HTML(DC::Embed::Document.new(resource, {}).code)
     embed_code.css("#DV-viewer-#{resource.id}").wont_be_empty
     
     # Embed code should include two script tags 

--- a/test/lib/embed_test.rb
+++ b/test/lib/embed_test.rb
@@ -1,11 +1,18 @@
 require_relative '../test_helper'
+require 'pry'
 
 describe DC::Embed do
+  
+  let(:resource) { Struct.new(:id, :url).new("1235", "https://lol.wat/1235") }
+  
   it "should require a resource" do
     Proc.new{ DC::Embed.new(nil, {}) }.must_raise ArgumentError
     Proc.new{ DC::Embed.new({}, {})  }.must_raise ArgumentError
 
-    struct = Struct.new(:id).new
-    DC::Embed.new(struct, {}).must_be_kind_of DC::Embed
+    DC::Embed.new(resource, {}).must_be_kind_of DC::Embed
   end
+  
+  it "should output HTML markup"
+  it "should output an oembed response as json"
+  it "should output a JST template"
 end

--- a/test/lib/embed_test.rb
+++ b/test/lib/embed_test.rb
@@ -12,7 +12,19 @@ describe DC::Embed do
     DC::Embed.new(resource, {}).must_be_kind_of DC::Embed
   end
   
-  it "should output HTML markup"
+  it "should output HTML markup" do
+    embed_code = Nokogiri::HTML(DC::Embed.new(resource, {}).code)
+    embed_code.css("#DV-viewer-#{resource.id}").wont_be_empty
+    
+    # Embed code should include two script tags 
+    external_scripts = embed_code.xpath("//script[@src]")
+    external_scripts.count.must_equal 1
+    external_scripts.first.attribute("src").value.must_match /loader.js$/
+
+    code_scripts     = embed_code.xpath("//script[not(@src)]")
+    code_scripts.count.must_equal 1
+  end
+
   it "should output an oembed response as json"
   it "should output a JST template"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path(File.dirname(__FILE__) + "/../config/environment")
 require 'rails/test_help'
 require 'sunspot_matchers/test_helper'
+require "minitest/autorun"
 
 PROCESSING_JOBS = []
 


### PR DESCRIPTION
This is two weeks of work building an oembed endpoint by @reefdog and me.

The highlights include:

* A new shiny 501 page (the error response for unsupported oembed types)
* An ApiController#oembed endpoint which accepts properly structured oembed requests
* A set of classes in the DC::Embed module which represent embeds and serve as the point for configuration and templating information from a resource object.
* Tests! (not super great coverage but enough to catch a variety of possible regressions)