### PR TITLE
Throw a 403 when optional API receives bad credentials

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,13 +97,10 @@ class ApplicationController < ActionController::Base
 
   def api_login_required
     authenticate_or_request_with_http_basic("DocumentCloud") do |email, password|
-      @current_account = Account.log_in(email, password)
-      if @current_account.blank?
-        false
-      else
+      if @current_account = Account.log_in(email, password)
         @current_organization = @current_account.organization
-        true
       end
+      @current_account
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -99,8 +99,10 @@ class ApplicationController < ActionController::Base
     authenticate_or_request_with_http_basic("DocumentCloud") do |email, password|
       if @current_account = Account.log_in(email, password)
         @current_organization = @current_account.organization
+        @current_account
+      else
+        return forbidden
       end
-      @current_account
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,16 +97,24 @@ class ApplicationController < ActionController::Base
 
   def api_login_required
     authenticate_or_request_with_http_basic("DocumentCloud") do |email, password|
-      return false unless @current_account = Account.log_in(email, password)
-      @current_organization = @current_account.organization
-      true
+      @current_account = Account.log_in(email, password)
+      if @current_account.blank?
+        false
+      else
+        @current_organization = @current_account.organization
+        true
+      end
     end
   end
 
   def api_login_optional
-    return if request.authorization.blank?
-    return unless @current_account = Account.log_in(*BasicAuth.user_name_and_password(request))
-    @current_organization = @current_account.organization
+    if request.authorization.blank?
+      # Public user
+      true
+    else
+      # The user is trying to log in. If the username/password is wrong, fail.
+      api_login_required
+    end
   end
   
   def allow_iframe

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -63,11 +63,17 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal doc.canonical_id, json_body['documents'].first['id']
   end
 
+  def test_api_login_required_returns_http_401
+    get :upload
+    assert_response 401
+  end
+
   def test_search_works_if_authenticated
     # authentication is optional, but it can get you more docs
     account = accounts(:louis)
     request.headers['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(account.email, 'password')
     get(:search, q: "document:#{doc.id}", format: :json)
+    assert_response 200
     assert_equal 1, json_body['total']
     assert_equal doc.canonical_id, json_body['documents'].first['id']
   end
@@ -76,6 +82,7 @@ class ApiControllerTest < ActionController::TestCase
     # otherwise the user might enter the wrong password and be sad the extra docs are missing
     # https://github.com/documentcloud/documentcloud/issues/89
     request.headers['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("WRONG-email@example.org", "WRONG-password")
+    refute request.authorization.blank?
     get(:search, q: "document:#{doc.id}", format: :json)
     assert_response 401
   end

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -63,7 +63,7 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal doc.canonical_id, json_body['documents'].first['id']
   end
 
-  def test_api_login_required_returns_http_401
+  def test_api_login_required_returns_unauthorized
     get :upload
     assert_response 401
   end
@@ -84,7 +84,7 @@ class ApiControllerTest < ActionController::TestCase
     request.headers['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("WRONG-email@example.org", "WRONG-password")
     refute request.authorization.blank?
     get(:search, q: "document:#{doc.id}", format: :json)
-    assert_response 401
+    assert_response 403
   end
 
   def test_it_requires_authentication

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -63,6 +63,23 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal doc.canonical_id, json_body['documents'].first['id']
   end
 
+  def test_search_works_if_authenticated
+    # authentication is optional, but it can get you more docs
+    account = accounts(:louis)
+    request.headers['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(account.email, 'password')
+    get(:search, q: "document:#{doc.id}", format: :json)
+    assert_equal 1, json_body['total']
+    assert_equal doc.canonical_id, json_body['documents'].first['id']
+  end
+
+  def test_search_doesnt_work_if_authentication_fails
+    # otherwise the user might enter the wrong password and be sad the extra docs are missing
+    # https://github.com/documentcloud/documentcloud/issues/89
+    request.headers['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("WRONG-email@example.org", "WRONG-password")
+    get(:search, q: "document:#{doc.id}", format: :json)
+    assert_response 401
+  end
+
   def test_it_requires_authentication
     [ :upload, :project, :projects, :update, :destroy, :create_project, :update_project, :destroy_project ].each do | action |
       get action


### PR DESCRIPTION
Implements #112 plus a few additional changes, closes #89.