### PR TITLE
AWS: Use region specified in documentcloud.yml

### DIFF
--- a/config/document_cloud.yml
+++ b/config/document_cloud.yml
@@ -4,8 +4,9 @@ defaults: &defaults
   server_root:          dev.dcloud.org
   large_file_storage:   /mnt/large_files
   aws_zone:             us-east-1c
+  aws_region:           us-east-1
   preconfigured_ami_id: <%= secrets['ami'] %>
-  asset_root:         "dev.dcloud.org"
+  asset_root:           "dev.dcloud.org"
 
 development:
   <<: *defaults

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -6,5 +6,6 @@ AWS.config(
   :logger            => Rails.logger,
   :http_idle_timeout => 60,
   :http_open_timeout => 30,
-  :http_read_timeout => 300
+  :http_read_timeout => 300,
+  :region            => DC::CONFIG['aws_region']
 )

--- a/lib/dc/store/aws_s3_store.rb
+++ b/lib/dc/store/aws_s3_store.rb
@@ -14,13 +14,14 @@ module DC
 
       # 60 seconds for persistent connections.
       S3_PARAMS       = {:connection_lifetime => 60}
+      AWS_REGION      = DC::CONFIG['aws_region']
 
       ACCESS_TO_ACL   = Hash.new(:private)
       DC::Access::PUBLIC_LEVELS.each{ |level| ACCESS_TO_ACL[level] = :public_read }
 
       module ClassMethods
         def asset_root
-          "https://s3.amazonaws.com/#{BUCKET_NAME}"
+          "https://s3-#{AWS_REGION}.amazonaws.com/#{BUCKET_NAME}"
         end
         def web_root
           asset_root


### PR DESCRIPTION
Specifying the region in `documentcloud.yml` makes it easy to point to a particular region instead of the default `us-east-1`. This would then be passed to the AWS initializer.

This pull request also fixes issue raised by @reefdog [here](https://github.com/documentcloud/documentcloud/pull/131).

Ref: http://ruby.awsblog.com/post/TxVOTODBPHAEP9/Working-with-Regions