### PR TITLE
Add Indonesian OCR support.

### DIFF
--- a/lib/dc/language.rb
+++ b/lib/dc/language.rb
@@ -13,6 +13,7 @@ module DC
       'fra' => 'French',
       'deu' => 'German',
       'hun' => 'Hungarian',
+      'ind' => 'Indonesian',
       'ita' => 'Italian',
       'jpn' => 'Japanese',
       'kor' => 'Korean',

--- a/public/javascripts/model/language.js
+++ b/public/javascripts/model/language.js
@@ -10,6 +10,7 @@ dc.language = {
     'fra' : 'French',
     'deu' : 'German',
     'hun' : 'Hungarian',
+    'ind' : 'Indonesian',
     'ita' : 'Italian',
     'jpn' : 'Japanese',
     'kor' : 'Korean',


### PR DESCRIPTION
Per https://github.com/documentcloud/documentcloud/issues/228

The presence of the Indonesian language packs on the servers needs to be verified.