### PR TITLE
Hotfix document modifications getting stuck

### DIFF
--- a/app/models/processing_job.rb
+++ b/app/models/processing_job.rb
@@ -37,7 +37,7 @@ class ProcessingJob < ActiveRecord::Base
       case object.action
       when "update_access"
         "#{DC.server_root(:ssl => false)}/import/update_access"
-      when /(large_)?document_import/
+      when /(large_)?document_import|redact_pages|reorder_pages|remove_pages/
         "#{DC.server_root(:ssl => false)}/import/cloud_crowd"
       else
         ""

--- a/app/models/processing_job.rb
+++ b/app/models/processing_job.rb
@@ -37,7 +37,7 @@ class ProcessingJob < ActiveRecord::Base
       case object.action
       when "update_access"
         "#{DC.server_root(:ssl => false)}/import/update_access"
-      when /(large_)?document_import|redact_pages|reorder_pages|remove_pages/
+      when /(large_)?document_import|redact_pages|document_insert_pages|document_reorder_pages|document_remove_pages/
         "#{DC.server_root(:ssl => false)}/import/cloud_crowd"
       else
         ""

--- a/app/models/processing_job.rb
+++ b/app/models/processing_job.rb
@@ -37,7 +37,7 @@ class ProcessingJob < ActiveRecord::Base
       case object.action
       when "update_access"
         "#{DC.server_root(:ssl => false)}/import/update_access"
-      when /(large_)?document_import|redact_pages|document_insert_pages|document_reorder_pages|document_remove_pages/
+      when /^(large_)?document_import|redact_pages|document_insert_pages|document_reorder_pages|document_remove_pages|reindex_document$/
         "#{DC.server_root(:ssl => false)}/import/cloud_crowd"
       else
         ""


### PR DESCRIPTION
Document actions that need to report back to the platform upon completion are effectively whitelisted by a switch statement. This statement was incomplete. Fill it out with more actions.

This should really be defined in a separate place so that modifying the action names (e.g. in the Document model) trickles down to here.

Affects #272 