### PR TITLE
Cache JSON responses

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -43,7 +43,7 @@ class AnnotationsController < ApplicationController
     note_attrs[:access] = ACCESS_MAP[note_attrs[:access].to_sym]
     doc = current_document
     return forbidden unless note_attrs[:access] == PRIVATE || current_account.allowed_to_comment?(doc)
-    expire_page doc.canonical_js_cache_path if doc.cacheable?
+    expire_pages doc.cache_paths if doc.cacheable?
     note_attrs[:organization_id] = current_account.organization_id
     anno = doc.annotations.create(note_attrs.merge(
       :account_id      => current_account.id
@@ -62,8 +62,8 @@ class AnnotationsController < ApplicationController
     attrs = pick(params, :title, :content, :access)
     attrs[:access] = DC::Access::ACCESS_MAP[attrs[:access].to_sym]
     anno.update_attributes(attrs)
-    expire_page current_document.canonical_js_cache_path if current_document.cacheable?
-    expire_page current_annotation.canonical_js_cache_path if current_annotation.cacheable?
+    expire_pages current_document.cache_paths if current_document.cacheable?
+    expire_pages current_annotation.cache_paths if current_annotation.cacheable?
     anno.reset_public_note_count
     json anno
   end
@@ -76,7 +76,7 @@ class AnnotationsController < ApplicationController
       return json(anno, 403)
     end
     anno.destroy
-    expire_page current_document.canonical_js_cache_path if current_document.cacheable?
+    expire_pages current_document.cache_paths if current_document.cacheable?
     json nil
   end
 

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -18,7 +18,7 @@ class AnnotationsController < ApplicationController
       format.js do
         json = current_annotation.canonical(:include_image_url => true, :include_document_url => true).to_json
         js = "dc.embed.noteCallback(#{json})"
-        cache_page js if current_annotation.cacheable? && PUBLIC_LEVELS.include?(current_document.access)
+        cache_page js if current_annotation.cacheable?
         render :js => js
       end
       format.html do

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -43,7 +43,7 @@ class AnnotationsController < ApplicationController
     note_attrs[:access] = ACCESS_MAP[note_attrs[:access].to_sym]
     doc = current_document
     return forbidden unless note_attrs[:access] == PRIVATE || current_account.allowed_to_comment?(doc)
-    expire_page doc.canonical_cache_path if doc.cacheable?
+    expire_page doc.canonical_js_cache_path if doc.cacheable?
     note_attrs[:organization_id] = current_account.organization_id
     anno = doc.annotations.create(note_attrs.merge(
       :account_id      => current_account.id
@@ -62,8 +62,8 @@ class AnnotationsController < ApplicationController
     attrs = pick(params, :title, :content, :access)
     attrs[:access] = DC::Access::ACCESS_MAP[attrs[:access].to_sym]
     anno.update_attributes(attrs)
-    expire_page current_document.canonical_cache_path if current_document.cacheable?
-    expire_page current_annotation.canonical_cache_path if current_annotation.cacheable?
+    expire_page current_document.canonical_js_cache_path if current_document.cacheable?
+    expire_page current_annotation.canonical_js_cache_path if current_annotation.cacheable?
     anno.reset_public_note_count
     json anno
   end
@@ -76,7 +76,7 @@ class AnnotationsController < ApplicationController
       return json(anno, 403)
     end
     anno.destroy
-    expire_page current_document.canonical_cache_path if current_document.cacheable?
+    expire_page current_document.canonical_js_cache_path if current_document.cacheable?
     json nil
   end
 

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -15,6 +15,11 @@ class AnnotationsController < ApplicationController
   def show
     return not_found unless current_annotation
     respond_to do |format|
+      format.json do
+        @response = current_annotation.canonical(:include_image_url => true, :include_document_url => true)
+        cache_page @response if current_annotation.cacheable?
+        json_response
+      end
       format.js do
         json = current_annotation.canonical(:include_image_url => true, :include_document_url => true).to_json
         js = "dc.embed.noteCallback(#{json})"

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -117,7 +117,7 @@ class ApiController < ApplicationController
     attrs[:access] = ACCESS_MAP[attrs[:access].to_sym] if attrs[:access]
     success = doc.secure_update attrs, current_account
     return json(doc, 403) unless success
-    expire_page doc.canonical_js_cache_path if doc.cacheable?
+    expire_pages doc.cache_paths if doc.cacheable?
     @response = {'document' => doc.canonical(:access => true, :sections => true, :annotations => true)}
     json_response
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -117,7 +117,7 @@ class ApiController < ApplicationController
     attrs[:access] = ACCESS_MAP[attrs[:access].to_sym] if attrs[:access]
     success = doc.secure_update attrs, current_account
     return json(doc, 403) unless success
-    expire_page doc.canonical_cache_path if doc.cacheable?
+    expire_page doc.canonical_js_cache_path if doc.cacheable?
     @response = {'document' => doc.canonical(:access => true, :sections => true, :annotations => true)}
     json_response
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,6 +77,10 @@ class ApplicationController < ActionController::Base
     json @response
   end
 
+  def expire_pages(paths)
+    [paths].flatten.each { |path| expire_page path }
+  end
+
   # Select only a sub-set of passed parameters. Useful for whitelisting
   # attributes from the params hash before performing a mass-assignment.
   def pick(hash, *keys)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -278,7 +278,7 @@ class DocumentsController < ApplicationController
   end
   
   def clear_current_document_cache
-    expire_page current_document.canonical_cache_path
-    current_document.annotations.each{ |note| expire_page note.canonical_cache_path }
+    expire_page current_document.canonical_js_cache_path
+    current_document.annotations.each{ |note| expire_page note.canonical_js_cache_path }
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -28,6 +28,7 @@ class DocumentsController < ApplicationController
       format.text { redirect_to(doc.full_text_url) }
       format.json do
         @response = doc.canonical
+        cache_page @response if doc.cacheable?
         json_response
       end
       format.js do
@@ -278,7 +279,7 @@ class DocumentsController < ApplicationController
   end
   
   def clear_current_document_cache
-    expire_page current_document.canonical_js_cache_path
-    current_document.annotations.each{ |note| expire_page note.canonical_js_cache_path }
+    paths = current_document.cache_paths + current_document.annotations.map(&:cache_paths)
+    expire_pages paths
   end
 end

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -49,8 +49,8 @@ class ImportController < ApplicationController
 
   def expire_document_cache(document)
     if document
-      paths = [document.canonical_js_cache_path] + document.annotations.map(&:canonical_js_cache_path)
-      paths.each{ |path| expire_page path }
+      paths = document.cache_paths + document.annotations.map(&:cache_paths)
+      expire_pages paths
     end
   end
 end

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -49,7 +49,7 @@ class ImportController < ApplicationController
 
   def expire_document_cache(document)
     if document
-      paths = [document.canonical_cache_path] + document.annotations.map(&:canonical_cache_path)
+      paths = [document.canonical_js_cache_path] + document.annotations.map(&:canonical_js_cache_path)
       paths.each{ |path| expire_page path }
     end
   end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -16,7 +16,7 @@ class OrganizationsController < ApplicationController
 
     if membership.organization.language != params[:language]
       Document.where({ :organization_id=>membership.organization_id }).each do | doc |
-        expire_page doc.canonical_js_cache_path if doc.cacheable?
+        expire_pages doc.cache_paths if doc.cacheable?
       end
     end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -16,7 +16,7 @@ class OrganizationsController < ApplicationController
 
     if membership.organization.language != params[:language]
       Document.where({ :organization_id=>membership.organization_id }).each do | doc |
-        expire_page doc.canonical_cache_path if doc.cacheable?
+        expire_page doc.canonical_js_cache_path if doc.cacheable?
       end
     end
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -8,7 +8,7 @@ class SectionsController < ApplicationController
     return json(nil, 403) unless current_account.allowed_to_edit?(doc)
     doc.sections.destroy_all
     sections.each {|s| doc.sections.create(pick(s, :title, :page_number)) }
-    expire_page doc.canonical_cache_path if doc.cacheable?
+    expire_page doc.canonical_js_cache_path if doc.cacheable?
     json nil
   end
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -8,7 +8,7 @@ class SectionsController < ApplicationController
     return json(nil, 403) unless current_account.allowed_to_edit?(doc)
     doc.sections.destroy_all
     sections.each {|s| doc.sections.create(pick(s, :title, :page_number)) }
-    expire_page doc.canonical_js_cache_path if doc.cacheable?
+    expire_pages doc.cache_paths if doc.cacheable?
     json nil
   end
 

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -148,6 +148,15 @@ class Annotation < ActiveRecord::Base
     canonical_path(:js)
   end
   
+  # Effective duplicate of `canonical_path()` for explicitness
+  def canonical_json_cache_path
+    canonical_path(:json)
+  end
+  
+  def cache_paths
+    [canonical_js_cache_path, canonical_json_cache_path]
+  end
+
   def canonical(opts={})
     data = {'id' => id, 'page' => page_number, 'title' => title, 'content' => content, 'access' => access_name.to_s }
     data['location'] = {'image' => location} if location

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -144,7 +144,7 @@ class Annotation < ActiveRecord::Base
     "/documents/#{document.canonical_id}/annotations/#{id}.#{format}"
   end
 
-  def canonical_cache_path
+  def canonical_js_cache_path
     canonical_path(:js)
   end
   

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -511,6 +511,15 @@ class Document < ActiveRecord::Base
     canonical_path(:js)
   end
 
+  # Effective duplicate of `canonical_path()` for explicitness
+  def canonical_json_cache_path
+    canonical_path(:json)
+  end
+
+  def cache_paths
+    [canonical_js_cache_path, canonical_json_cache_path]
+  end
+
   def project_ids
     self.project_memberships.map {|m| m.project_id }
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -504,11 +504,11 @@ class Document < ActiveRecord::Base
   end
 
   def canonical_path(format = :json)
-    "documents/#{canonical_id}.#{format}"
+    "/documents/#{canonical_id}.#{format}"
   end
 
-  def canonical_cache_path
-    "/#{canonical_path(:js)}"
+  def canonical_js_cache_path
+    canonical_path(:js)
   end
 
   def project_ids

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -197,8 +197,8 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal "#{base}/pages", doc.pages_path
     assert_equal "#{base}/annotations", doc.annotations_path
     assert_equal "#{doc.id}-#{doc.slug}", doc.canonical_id
-    assert_equal "#{base}-#{doc.slug}.json", doc.canonical_path
-    assert_equal "/#{base}-#{doc.slug}.js", doc.canonical_cache_path
+    assert_equal "/#{base}-#{doc.slug}.json", doc.canonical_path
+    assert_equal "/#{base}-#{doc.slug}.js", doc.canonical_js_cache_path
     assert_equal "#{doc.slug}-p{page}-{size}.gif", doc.page_image_template
     assert_equal "#{doc.slug}-p{page}.txt", doc.page_text_template
     assert_equal "#{DC.cdn_root(:force_ssl=>true)}/#{slug}.pdf", doc.public_pdf_url

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -199,6 +199,7 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal "#{doc.id}-#{doc.slug}", doc.canonical_id
     assert_equal "/#{base}-#{doc.slug}.json", doc.canonical_path
     assert_equal "/#{base}-#{doc.slug}.js", doc.canonical_js_cache_path
+    assert_equal "/#{base}-#{doc.slug}.json", doc.canonical_json_cache_path
     assert_equal "#{doc.slug}-p{page}-{size}.gif", doc.page_image_template
     assert_equal "#{doc.slug}-p{page}.txt", doc.page_text_template
     assert_equal "#{DC.cdn_root(:force_ssl=>true)}/#{slug}.pdf", doc.public_pdf_url


### PR DESCRIPTION
We already cache the JSONP (`.js`) responses. Everywhere we do so, go ahead and cache the JSON (`.json`) responses, too. Justified consolidating some cache expiration methods and adding a JSON endpoint for notes.

We should do #281 pretty soon though.