### PR TITLE
Remove request.format check for ApplicationController#secure_only

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -132,7 +132,7 @@ class ApplicationController < ActionController::Base
   end
 
   def secure_only(status=301)
-    if !request.ssl? && (request.format.html? || request.format.nil?)
+    if !request.ssl?
       redirect_to DC.server_root(:force_ssl => true) + request.original_fullpath, :status => status
     end
   end


### PR DESCRIPTION
`secure_only` should redirect for clients that don't provide an HTTP `Accept` header that satisfies `html?` or `nil?`. I discovered this with cURL, but other user agents may be affected. 