### PR TITLE
Avoid POODLE attacks

### DIFF
--- a/config/server/files/nginx/nginx.conf
+++ b/config/server/files/nginx/nginx.conf
@@ -19,7 +19,7 @@ http {
 	tcp_nodelay on;
 	keepalive_timeout 2;
 	types_hash_max_size 2048;
-  client_max_body_size 400M;
+	client_max_body_size 400M;
 	# server_tokens off;
 
 	# server_names_hash_bucket_size 64;
@@ -38,19 +38,20 @@ http {
 	# Gzip Settings
 	##
 
-  gzip            on;
-  gzip_static     on;
-  gzip_comp_level 2;
-  gzip_proxied    any;
-  gzip_vary       on;
-  gzip_types      text/plain text/css application/x-javascript application/json text/xml application/xml application/xml+rss text/javascript;
+	gzip            on;
+	gzip_static     on;
+	gzip_comp_level 2;
+	gzip_proxied    any;
+	gzip_vary       on;
+	gzip_types      text/plain text/css application/x-javascript application/json text/xml application/xml application/xml+rss text/javascript;
 
 	# gzip_buffers 16 8k;
 	# gzip_http_version 1.1;
 
-  ssl_ciphers         ALL:!aNULL:!ADH:!eNULL:!MEDIUM:!LOW:!EXP:!kEDH:RC4+RSA:+HIGH;
-  ssl_session_cache   shared:SSL:10m;
-  ssl_session_timeout 10m;
+	ssl_ciphers         ALL:!aNULL:!ADH:!eNULL:!MEDIUM:!LOW:!EXP:!kEDH:RC4+RSA:+HIGH;
+	ssl_session_cache   shared:SSL:10m;
+	ssl_session_timeout 10m;
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
 	##
 	# nginx-naxsi config


### PR DESCRIPTION
According to Qualys, using SSL 3 makes you vulnerable to POODLE attack. - https://www.ssllabs.com/ssltest/analyze.html?d=documentcloud.org
 
Also clean up some of the weird tabs.