### PR TITLE
"Now we're www.overviewdocs.com"

### DIFF
--- a/public/javascripts/ui/workspace/toolbar.js
+++ b/public/javascripts/ui/workspace/toolbar.js
@@ -252,7 +252,7 @@ dc.ui.Toolbar = Backbone.View.extend({
     if (/\S/.test(query)) {
       dc.ui.Dialog.confirm(
         _.t('export_to_overview_explain'),
-        function() { window.open("https://www.overviewproject.org/imports/documentcloud/new/" + encodeURIComponent(query), '_blank'); },
+        function() { window.open("https://www.overviewdocs.com/imports/documentcloud/new/" + encodeURIComponent(query), '_blank'); },
         {
           saveText: _.t('export'),
           closeText: _.t('cancel')


### PR DESCRIPTION
Just making sure it's covered for future - https://blog.overviewdocs.com/2015/07/13/hi-now-were-www-overviewdocs-com/