### PR TITLE
Terms of Service update

### DIFF
--- a/app/views/home/terms/changelog.yml
+++ b/app/views/home/terms/changelog.yml
@@ -1,6 +1,8 @@
 - version:     1.0
-  current:     true
   description: Original terms that governed from launch.
+  start:       '2010-03-01'
+  end:         '2015-05-24'
 - version:     2.0
-  description: 'Many changes, see <a href="https://blog.documentcloud.org/blog/2016/04/updating-documentcloud-terms-of-service/">blog post</a> for details.'
+  current:     true
+  description: 'See <a href="https://blog.documentcloud.org/blog/2016/04/updating-documentcloud-terms-of-service/">blog post</a> for details on changes.'
   start:       '2016-05-25'


### PR DESCRIPTION
We notified DocumentCloud users in mid-April 2016 of an update to our Terms of Service. The notice included emails and a [blog post](https://blog.documentcloud.org/blog/2016/04/updating-documentcloud-terms-of-service/) highlighting changes. After a 30+-day notice period, the new ToS takes effect today, May 25, 2016. 

This pull request changes the default ToS viewed when a person visits the main terms page and retains the prior version.