### PR TITLE
Better urls and rearranging location of redirects.

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,6 +9,7 @@ class HomeController < ApplicationController
   before_action :bouncer if exclusive_access?
 
   def index
+    redirect_to search_url if logged_in? and env["PATH_INFO"].slice(0,5) != "/home"
     @document = Rails.cache.fetch( "homepage/featured_document" ) do
       time = Rails.env.production? ? 2.weeks.ago : nil
       Document.unrestricted.published.popular.random.since(time).first

--- a/app/controllers/workspace_controller.rb
+++ b/app/controllers/workspace_controller.rb
@@ -13,18 +13,15 @@ class WorkspaceController < ApplicationController
   # Main documentcloud.org page. Renders the workspace if logged in or
   # searching, the home page otherwise.
   def index
-    if logged_in?
-      if current_account.real?
-        @projects = Project.load_for(current_account)
-        @current_organization = current_account.organization
-        @organizations = Organization.all_slugs
-        @has_documents = Document.owned_by(current_account).exists?
-        return render :template => 'workspace/index'
-      else
-        return redirect_to '/public/search'
-      end
+    if logged_in? and current_account.real?
+      @projects = Project.load_for(current_account)
+      @current_organization = current_account.organization
+      @organizations = Organization.all_slugs
+      @has_documents = Document.owned_by(current_account).exists?
+      return render :template => 'workspace/index'
     end
-    redirect_to '/home'
+    Rails.logger.info(params)
+    redirect_to public_search_with_query_url(query: params[:query])
   end
 
   # Render a help page as regular HTML, including correctly re-directed links.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 DC::Application.routes.draw do
 
   # Homepage
-  get '/', to: 'workspace#index'
+  get '/', to: 'home#index'
 
   # Embed loaders
   get '/embed/loader/enhance', to: 'embed#enhance', as: 'embed_enhance'
@@ -15,7 +15,7 @@ DC::Application.routes.draw do
   get '/search/embed/:options.:format',    to: 'search#embed', q: /[^\/;,?]*/, options: /p-(\d+)-per-(\d+)-order-(\w+)-org-(\d+)(-secure)?/
 
   # Journalist workspace and surrounding HTML
-  get '/search',                  to: 'workspace#index'
+  get '/search',                  to: 'workspace#index', as: 'search'
   get '/search/preview',          to: 'search#preview', as: 'preview'
   get '/search/restricted_count', to: 'search#restricted_count'
   get '/search/:query',           to: 'workspace#index', query: /.*/
@@ -37,7 +37,7 @@ DC::Application.routes.draw do
 
   # Public search
   get '/public/search',        to: 'public#index', as: 'public_search'
-  get '/public/search/:query', to: 'public#index', query: /.*/
+  get '/public/search/:query', to: 'public#index', query: /.*/, as: 'public_search_with_query'
 
   # API
   scope(:api, controller: 'api') do


### PR DESCRIPTION
Okay, so this is an intermediary fix to the fact that it's problematic for users to link to projects.

Behavior before this pull request is as follows:

Journalists will put together a project, then find the project id (which should also be improved) and then will craft a link like `https://www.documentcloud.org/search/projectid:%201234-the-project-name` and send it out in a tweet or link to it.

Unless one is logged into DocumentCloud this link will instead (confusingly) redirect one to `/home`.

Here's a list of the current behavior:

If you're logged in:

- Navigating to `/` will redirect you to `/search`
- Navigating to `/search/:query` will display search results page.
- Navigating to `/public/search/:query` will redirect to `/search/:query`
- Navigating to `/home` will display the DocumentCloud info page.

If you're logged out:

- Navigating to `/` will redirect you to `/home`
- Navigating to `/home` will display the DocumentCloud info page.
- Navigating to `/search/:query` will redirect you to `/home`
- Navigating to `/public/search/query` will display the public search results page.

------------------------------------

The new behavior is as follows:

If you are logged in:

- Navigating to `/` will redirect you to `/search`
- Navigating to `/public/search/:query` will redirect to `/search/:query`
- Navigating to `/search/:query` will display the search results page.
- Navigating to `/home` will display the DocumentCloud info page.

If you are logged out:

- Navigating to `/` will display the DocumentCloud info page.
- Navigating to `/home` will display the DocumentCloud info page.
- Navigating to `/search/:query` will redirect to `/public/search/:query`
- Navigating to `/public/search/:query` will display the public search results page.

