### PR TITLE
Update & missing links

### DIFF
--- a/app/views/static/contributors.yml
+++ b/app/views/static/contributors.yml
@@ -2,7 +2,7 @@ partners:
    - - Gotham Gazette
      - http://gothamgazette.com
    - - National Security Archive
-     - http://gwu.edu/~nsarchiv
+     - http://nsarchive.gwu.edu
    - - New York Times
      - http://nytimes.com
    - - ProPublica
@@ -107,7 +107,7 @@ contributors:
    - - Deutsche Presse-Agentur
      - http://www.dpa.de
    - - Diamond Bar Patch
-     - http://diamondbar.patch.com
+     - http://patch.com/california/diamondbar-walnut
    - - Digital Advance NZ
      - http://digitaladvance.co.nz
    - - Edmonton Journal
@@ -156,8 +156,6 @@ contributors:
      - http://homicidewatch.org/
    - - Houston Chronicle
      - http://chron.com
-   - - Huffington Post Investigative Fund
-     - http://huffpostfund.org
    - - Investigate West
      - http://invw.org
    - - Investigative Reporting Workshop at American University


### PR DESCRIPTION
The Huffington Post Investigative Fund merged with the Center for Public Integrity. More data on this URL: http://www.nytimes.com/2010/10/19/business/media/19nonprofit.html?_r=0