### PR TITLE
Fix broken links for #450

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -53,8 +53,7 @@
     to make it public, but once you decide to publish, your documents
     join more than one million other primary source documents in our
     public catalog.
-    Use our document viewer to
-    <a href="http://www.pbs.org/newshour/spc/rundown/documents/mark-twain-concerning-the-interview.html">embed documents on your own website</a>
+    Use our document viewer to embed documents on your own website
     and introduce your audience to the larger paper trail behind your story.
   </div>
 

--- a/app/views/jst/workspace/workspace/document_embed_dialog.jst
+++ b/app/views/jst/workspace/workspace/document_embed_dialog.jst
@@ -53,7 +53,7 @@
       </label>
     </span>
     <p class="dialog_info selectable_text interface">
-      <%= _.t('publish_choose_display', '<a class="text_link" href="https://www.propublica.org/documents/item/bp-update-to-the-house-resources-committee" target="_blank">','</a>', '<a class="text_link" href="https://www.muckrock.com/news/archives/2015/may/15/30-rock-fcc-complaints/" target="_blank">','</a>' ) %>
+      <%= _.t('publish_choose_display', '<a class="text_link" href="https://www.propublica.org/documents/bp-update-to-the-house-resources-committee" target="_blank">','</a>', '<a class="text_link" href="https://www.muckrock.com/news/archives/2015/may/15/30-rock-fcc-complaints/" target="_blank">','</a>' ) %>
     </p>
   </div>
 

--- a/public/javascripts/editor/control_panel.js
+++ b/public/javascripts/editor/control_panel.js
@@ -51,7 +51,8 @@ dc.ui.ViewerControlPanel = Backbone.View.extend({
     $(this.el).html(JST['control_panel']({
       isReviewer      : dc.app.editor.options.isReviewer,
       isOwner         : dc.app.editor.options.isOwner,
-      workspacePrefix : accessWorkspace ? '#' : '',
+      // TODO: temporary hack for https://github.com/documentcloud/documentcloud/issues/450
+      workspacePrefix : '', //accessWorkspace ? '#' : '',
       docAccess       : docAccess,
       orgName         : this.viewer.api.getContributorOrganization()
     }));


### PR DESCRIPTION
Definitely not fixed all the way, but removes some of the brokenness :)

* Couldn't find an updated PBS link, so just made it not a link anymore

* Fixed the Propublica link (extra "item" in path) so it goes to a Propublica page, but that page just says "iframe?" in the content area, so still probably not the right link.

* The help links was weird - seems workspacePrefix is determined by whether accessWorkspace is defined or not - and the code makes it look like it always will be. And when accessWorkspace is defined, a "#" is inserted, which creates a link that doesn't seem to resolve to anything (/help vs /#help). Temporary hack was to just remove the "#". But I don't have an account yet, so haven't tested it.