### PR TITLE
Deferring Text Processing

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -173,28 +173,31 @@ class Document < ActiveRecord::Base
                (params[:access] ? ACCESS_MAP[params[:access].to_sym] : PRIVATE)
     email_me = params[:email_me] ? params[:email_me].to_i : false
     file_ext = File.extname(name).downcase[1..-1]
-
-    doc = self.create!(
-      :organization_id    => organization.id,
-      :account_id         => account.id,
-      :access             => PENDING,
-      :page_count         => 0,
-      :title              => title,
-      :description        => params[:description],
-      :source             => params[:source],
-      :related_article    => params[:related_article],
-      :remote_url         => params[:published_url] || params[:remote_url],
-      :language           => params[:language] || account.language,
-      :original_extension => file_ext
-    )
+  
+    doc = self.create!({
+      organization_id:    organization.id,
+      account_id:         account.id,
+      access:             PENDING,
+      page_count:         0,
+      title:              title,
+      description:        params[:description],
+      source:             params[:source],
+      related_article:    params[:related_article],
+      remote_url:         params[:published_url] || params[:remote_url],
+      language:           params[:language] || account.language,
+      original_extension: file_ext
+    })
+  
     import_options = {
-      :access          => access,
-      :email_me        => email_me,
-      :secure          => params[:secure],
-      :organization_id => organization.id,
-      :account_id      => account.id,
-      :force_ocr       => params[:force_ocr]
+      access: access,
+      email_me: email_me,
+      secure: params[:secure],
+      organization_id: organization.id,
+      account_id: account.id,
+      force_ocr: params[:force_ocr],
+      images_only: params[:defer_text]
     }
+
     if params[:url]
       import_options.merge!(:url => params[:url])
     else

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -868,9 +868,16 @@ class Document < ActiveRecord::Base
     options[:id] = id
     self.update_attributes :access => PENDING
     #record_job(DC::Import::CloudCrowdImporter.new.import([id], options, self.low_priority?).body)
+    action = if options[:action] == 'api_document_import'
+      'api_document_import'
+    elsif self.low_priority?
+      'large_document_import'
+    else
+      'document_import'
+    end
     
     self.processing_jobs.new(
-      :action     => self.low_priority? ? 'large_document_import' : 'document_import',
+      :action     => action,
       :title      => title,
       :account_id => account_id,
       :options    => options


### PR DESCRIPTION
As a general matter i don't recommend this, but I've tested this out in anger and it does what it's supposed to.

DocumentCloud's DocumentImport action splits into two main tasks, processing images, and processing text.  We can already run each of those independently (notably for reprocessing text, or reprocessing images).

The changes here expose skipping text processing entirely.  I don't generally recommend this, and there needs to be some other process which will circle back around and process text, but this would serve as a basis for doing so.

Additionally, added a mechanism for flagging incoming import jobs as `api_document_import` so it can be handled separately and priority given to `document_import` and `large_document_import` jobs.